### PR TITLE
fix: Lambda RMU on LocalStack with DynamoDB Streams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - uses: pnpm/action-setup@v3
         with:
           version: 8
+      - uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: "2"
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ yarn-error.log
 .turbo/
 .turbo/*
 
+# Local developer overrides (see common.env.default)
+common.env
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "references/okite-ai"]
+	path = references/okite-ai
+	url = git@github.com:j5ik2o/okite-ai.git

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,7 +19,7 @@
 - [x] Read API Server(GraphQL)
 - [x] Read Model Updater on Local
 - [x] Docker Compose Support
-- [ ] Read Model Updater on AWS Lambda
+- [x] Read Model Updater on AWS Lambda（LocalStack 向けビルド／デプロイと `common.env`。詳細は [ビルドとテスト](./docs/BUILD_AND_TEST.ja.md)）
 - [ ] Deployment to AWS
 
 ## 概要

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please refer to [here](https://github.com/j5ik2o/cqrs-es-example) for implementa
 - [x] Read API Server(GraphQL)
 - [x] Read Model Updater on Local
 - [x] Docker Compose Support
-- [ ] Read Model Updater on AWS Lambda
+- [x] Read Model Updater on AWS Lambda (LocalStack: build/deploy scripts and `common.env`; see [Build and Test](./docs/BUILD_AND_TEST.md))
 - [ ] Deployment to AWS
 
 ## Component Composition

--- a/common.env.default
+++ b/common.env.default
@@ -1,0 +1,29 @@
+# Copy to common.env and adjust. common.env is gitignored.
+# Host-side AWS CLI uses this URL (Compose maps LocalStack to host port 34566).
+LOCALSTACK_ENDPOINT_URL=http://localhost:34566
+
+AWS_REGION=ap-northeast-1
+AWS_DEFAULT_REGION=ap-northeast-1
+AWS_ACCESS_KEY_ID=x
+AWS_SECRET_ACCESS_KEY=x
+
+STREAM_JOURNAL_TABLE_NAME=journal
+STREAM_MAX_ITEM_COUNT=32
+
+# Lambda container reaches MySQL on the Compose network (see docker-compose-databases.yml).
+DATABASE_URL_LAMBDA=mysql://ceer:ceer@mysql-local:3306/ceer
+
+FUNCTION_NAME=read-model-updater-rmu
+# LocalStack 2.x では nodejs20.x が無い場合があるため既定は nodejs18.x
+LAMBDA_RUNTIME=nodejs18.x
+COMPOSE_PROJECT=cqrs-es-example-js
+
+# 1 = after deploy, stop container read-model-updater-1 to avoid double stream processing
+STOP_LOCAL_RMU_AFTER_LAMBDA_DEPLOY=1
+
+# docker-compose-up.sh: build/deploy Lambda zip when non-zero
+DOCKER_COMPOSE_UP_BUILD_LAMBDA=1
+DOCKER_COMPOSE_UP_DEPLOY_LAMBDA=1
+
+# Override if your compose project name differs (affects LAMBDA_DOCKER_NETWORK default in compose).
+# LAMBDA_DOCKER_NETWORK=cqrs-es-example-js_default

--- a/docs/BUILD_AND_TEST.ja.md
+++ b/docs/BUILD_AND_TEST.ja.md
@@ -27,3 +27,24 @@ $ pnpm docker-build
 $ pnpm docker-compose-up
 $ pnpm verify-group-chat # E2E
 ```
+
+## Read Model Updater Lambda（LocalStack）
+
+Rust 版と同様に、Read Model Updater を LocalStack 上の Lambda（DynamoDB ストリーム → Lambda → MySQL）として動かす手順です。
+
+1. リポジトリルートに `common.env.default` を `common.env` としてコピーするか、`docker-compose-up.sh` / `docker-compose-e2e-test.sh` に任せて自動生成する。`common.env` は `.gitignore` されます。
+2. ホストから AWS CLI で LocalStack に接続するときは **`http://localhost:34566`** を使います（Compose がコンテナの `4566` をホストの `34566` に公開）。Compose 内のサービスからは `http://localstack:4566` です。
+3. デプロイ用 zip（Docker `linux/amd64`、Prisma の Lambda 用バイナリを含む）のビルド:
+
+   ```shell
+   $ pnpm build-read-model-updater-lambda
+   ```
+
+   成果物は `dist/lambda/read-model-updater/function.zip` です。
+
+4. `pnpm docker-compose-up` および `pnpm docker-compose-e2e-test` は、必要に応じて zip をビルドし、LocalStack 待機後に `deploy-read-model-updater-localstack.sh` を実行し、既定でコンテナ `read-model-updater-1` を停止します（ストリームの二重処理を防ぐため）。`DOCKER_COMPOSE_UP_DEPLOY_LAMBDA=0` や `DOCKER_COMPOSE_UP_BUILD_LAMBDA=0` でスキップできます。E2E 用コンテナは `profile: e2e` とし、スタック起動と Lambda デプロイの後に `verify-group-chat.sh` が走るようにしています。
+5. Compose 起動後に手動デプロイする場合:
+
+   ```shell
+   $ pnpm deploy-read-model-updater-localstack
+   ```

--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -27,3 +27,24 @@ $ pnpm docker-build
 $ pnpm docker-compose-up
 $ pnpm verify-group-chat # E2E
 ```
+
+## Read Model Updater Lambda (LocalStack)
+
+This mirrors the Rust example: run the Read Model Updater as an AWS Lambda on LocalStack (DynamoDB stream → Lambda → MySQL).
+
+1. Copy `common.env.default` to `common.env` at the repo root, or let `docker-compose-up.sh` / `docker-compose-e2e-test.sh` create it. `common.env` is gitignored.
+2. From the host, point the AWS CLI at **`http://localhost:34566`** (Compose maps container `4566` to host `34566`). Inside Compose, services use `http://localstack:4566`.
+3. Build the deployment zip (Docker `linux/amd64`, Prisma engines for Lambda):
+
+   ```shell
+   $ pnpm build-read-model-updater-lambda
+   ```
+
+   Output: `dist/lambda/read-model-updater/function.zip`.
+
+4. `pnpm docker-compose-up` and `pnpm docker-compose-e2e-test` can build the zip (unless `DOCKER_COMPOSE_UP_BUILD_LAMBDA=0`), wait for LocalStack, run `deploy-read-model-updater-localstack.sh`, and by default stop the `read-model-updater-1` container to avoid double-processing the stream. Set `DOCKER_COMPOSE_UP_DEPLOY_LAMBDA=0` to skip deploy. The e2e script brings stacks up, deploys Lambda, then runs the `e2e-test` container (`profile: e2e`) so GraphQL is ready before `verify-group-chat.sh` runs.
+5. To deploy manually after Compose is up:
+
+   ```shell
+   $ pnpm deploy-read-model-updater-localstack
+   ```

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+node = "20"
+python = "3"
+"npm:@fission-ai/openspec" = "1.2.0"
+"npm:happy-coder" = "0.13.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "docker-compose-up": "./tools/scripts/docker-compose-up.sh",
     "docker-compose-up-db": "./tools/scripts/docker-compose-up.sh -d",
     "docker-compose-down": "./tools/scripts/docker-compose-down.sh",
+    "build-read-model-updater-lambda": "./tools/scripts/build-read-model-updater-lambda.sh",
+    "deploy-read-model-updater-localstack": "./tools/scripts/deploy-read-model-updater-localstack.sh",
     "create-group-chat": "./tools/scripts/curl-create-group-chat.sh",
     "verify-group-chat": "./tools/e2e-test/verify-group-chat.sh",
     "build": "turbo build",

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-bootstrap",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "start": "ts-node src/index.ts",
     "start-write-api": "node dist/index.js writeApi",

--- a/packages/bootstrap/src/lambda-rmu-handler.ts
+++ b/packages/bootstrap/src/lambda-rmu-handler.ts
@@ -1,0 +1,29 @@
+import { PrismaClient } from "@prisma/client";
+import type { DynamoDBStreamEvent, Handler } from "aws-lambda";
+import { GroupChatDao, ReadModelUpdater } from "cqrs-es-example-js-rmu";
+
+let prisma: PrismaClient | undefined;
+let readModelUpdater: ReadModelUpdater | undefined;
+
+function getReadModelUpdater(): ReadModelUpdater {
+  if (readModelUpdater) {
+    return readModelUpdater;
+  }
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
+  prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
+  readModelUpdater = ReadModelUpdater.of(GroupChatDao.of(prisma));
+  return readModelUpdater;
+}
+
+export const handler: Handler<DynamoDBStreamEvent, void> = async (event) => {
+  await getReadModelUpdater().updateReadModel(event);
+};

--- a/packages/command/domain/package.json
+++ b/packages/command/domain/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-command-domain",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && rimraf dist/internal/*.test.d.ts && rimraf dist/internal/*.test.js && rimraf dist/internal/test && rimraf dist/group-chat/*.test.*",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache",

--- a/packages/command/interface-adaptor-if/package.json
+++ b/packages/command/interface-adaptor-if/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-command-interface-adaptor-if",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && rm -f dist/internal/*.test.d.ts && rm -f dist/internal/*.test.js && rm -fr dist/internal/test",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache",

--- a/packages/command/interface-adaptor-impl/package.json
+++ b/packages/command/interface-adaptor-impl/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-command-interface-adaptor-impl",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && rimraf dist/internal/*.test.d.ts && rimraf dist/internal/*.test.js && rimraf dist/internal/test && rimraf dist/repository/group-chat/*.test.*",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache",

--- a/packages/command/interface-adaptor-impl/src/graphql/resolvers.ts
+++ b/packages/command/interface-adaptor-impl/src/graphql/resolvers.ts
@@ -20,7 +20,7 @@ import type { TaskEither } from "fp-ts/TaskEither";
 import { pipe } from "fp-ts/function";
 import { GraphQLError } from "graphql/error";
 import { Arg, Ctx, Mutation, Query, Resolver } from "type-graphql";
-import type {
+import {
   AddMemberInput,
   CreateGroupChatInput,
   DeleteGroupChatInput,
@@ -45,7 +45,7 @@ class GroupChatCommandResolver {
   @Mutation(() => GroupChatOutput)
   async createGroupChat(
     @Ctx() { groupChatCommandProcessor }: CommandContext,
-    @Arg("input") input: CreateGroupChatInput,
+    @Arg("input", () => CreateGroupChatInput) input: CreateGroupChatInput,
   ): Promise<GroupChatOutput> {
     return pipe(
       this.validateGroupChatName(input.name),
@@ -75,7 +75,7 @@ class GroupChatCommandResolver {
   @Mutation(() => GroupChatOutput)
   async deleteGroupChat(
     @Ctx() { groupChatCommandProcessor }: CommandContext,
-    @Arg("input") input: DeleteGroupChatInput,
+    @Arg("input", () => DeleteGroupChatInput) input: DeleteGroupChatInput,
   ): Promise<GroupChatOutput> {
     return pipe(
       this.validateGroupChatId(input.groupChatId),
@@ -105,7 +105,7 @@ class GroupChatCommandResolver {
   @Mutation(() => GroupChatOutput)
   async renameGroupChat(
     @Ctx() { groupChatCommandProcessor }: CommandContext,
-    @Arg("input") input: RenameGroupChatInput,
+    @Arg("input", () => RenameGroupChatInput) input: RenameGroupChatInput,
   ): Promise<GroupChatOutput> {
     return pipe(
       this.validateGroupChatId(input.groupChatId),
@@ -151,7 +151,7 @@ class GroupChatCommandResolver {
   @Mutation(() => GroupChatOutput)
   async addMember(
     @Ctx() { groupChatCommandProcessor }: CommandContext,
-    @Arg("input") input: AddMemberInput,
+    @Arg("input", () => AddMemberInput) input: AddMemberInput,
   ): Promise<GroupChatOutput> {
     return pipe(
       this.validateGroupChatId(input.groupChatId),
@@ -211,7 +211,7 @@ class GroupChatCommandResolver {
   @Mutation(() => GroupChatOutput)
   async removeMember(
     @Ctx() { groupChatCommandProcessor }: CommandContext,
-    @Arg("input") input: RemoveMemberInput,
+    @Arg("input", () => RemoveMemberInput) input: RemoveMemberInput,
   ): Promise<GroupChatOutput> {
     return pipe(
       this.validateGroupChatId(input.groupChatId),
@@ -257,7 +257,7 @@ class GroupChatCommandResolver {
   @Mutation(() => MessageOutput)
   async postMessage(
     @Ctx() { groupChatCommandProcessor }: CommandContext,
-    @Arg("input") input: PostMessageInput,
+    @Arg("input", () => PostMessageInput) input: PostMessageInput,
   ): Promise<MessageOutput> {
     return pipe(
       this.validateGroupChatId(input.groupChatId),
@@ -307,7 +307,7 @@ class GroupChatCommandResolver {
   @Mutation(() => GroupChatOutput)
   async deleteMessage(
     @Ctx() { groupChatCommandProcessor }: CommandContext,
-    @Arg("input") input: DeleteMessageInput,
+    @Arg("input", () => DeleteMessageInput) input: DeleteMessageInput,
   ): Promise<GroupChatOutput> {
     return pipe(
       this.validateGroupChatId(input.groupChatId),

--- a/packages/command/processor/package.json
+++ b/packages/command/processor/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-command-processor",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && rimraf dist/internal/*.test.d.ts && rimraf dist/internal/*.test.js && rimraf dist/internal/test && rimraf dist/group-chat/*.test.*",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache",

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-infrastructure",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "start": "ts-node src/index.ts",
     "start-write-api": "node dist/index.js writeApi",

--- a/packages/query/interface-adaptor/package.json
+++ b/packages/query/interface-adaptor/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-query-interface-adaptor",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prisma:generate": "prisma generate",
     "build": "tsc && rimraf dist/internal/*.test.d.ts && rimraf dist/internal/*.test.js && rimraf dist/internal/test && rimraf dist/*.test.*",

--- a/packages/rmu/package.json
+++ b/packages/rmu/package.json
@@ -2,7 +2,8 @@
   "name": "cqrs-es-example-js-rmu",
   "version": "1.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prisma:generate": "prisma generate",
     "build": "tsc && rimraf dist/internal/*.test.d.ts && rimraf dist/internal/*.test.js && rimraf dist/internal/test && rimraf dist/*.test.*",

--- a/packages/rmu/prisma/schema.prisma
+++ b/packages/rmu/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "rhel-openssl-3.0.x", "rhel-openssl-1.0.x"]
 }
 
 datasource db {

--- a/packages/rmu/src/update-read-model.ts
+++ b/packages/rmu/src/update-read-model.ts
@@ -44,15 +44,22 @@ class ReadModelUpdater {
         this.logger.warn("No NewImage");
         return;
       }
-      const base64EncodedPayload = attributeValues.payload.B;
-      if (!base64EncodedPayload) {
+      const rawPayload = attributeValues.payload.B;
+      if (!rawPayload) {
         this.logger.warn("No payload");
         return;
       }
-      const payload = this.decoder.decode(
-        new Uint8Array(base64EncodedPayload.split(",").map(Number)),
-      );
-      const payloadJson = JSON.parse(payload);
+      let payloadJson: unknown;
+      try {
+        // LocalStack: B フィールドに生 JSON 文字列が入る
+        payloadJson = JSON.parse(rawPayload);
+      } catch {
+        // AWS Lambda: Base64, ローカル RMU: カンマ区切り数値文字列
+        const payloadBytes = /^\d+(,\d+)*$/.test(rawPayload)
+          ? new Uint8Array(rawPayload.split(",").map(Number))
+          : new Uint8Array(Buffer.from(rawPayload, "base64"));
+        payloadJson = JSON.parse(this.decoder.decode(payloadBytes));
+      }
       const groupChatEvent = convertJSONToGroupChatEvent(payloadJson);
       switch (groupChatEvent.symbol) {
         case GroupChatCreatedTypeSymbol: {

--- a/tools/docker-compose/docker-compose-databases.yml
+++ b/tools/docker-compose/docker-compose-databases.yml
@@ -47,32 +47,25 @@ services:
       - mysql
   localstack:
     image: localstack/localstack:2.3.2
+    container_name: localstack-main
     hostname: localstack-local
     ports:
       - "34566:4566"
       - "34571:4571"
-      - "${PORT_WEB_UI-38083}:${PORT_WEB_UI-8080}"
     environment:
       DEBUG: 1
       LOCALSTACK_API_KEY: ${LOCALSTACK_API_KEY- }
-      PORT_WEB_UI: ${PORT_WEB_UI- }
-      PARITY_AWS_ACCESS_KEY_ID: 1
       EAGER_SERVICE_LOADING: 1
-      SERVICES: cloudwatch,dynamodb,dynamodbstreams
-      # SERVICES: cloudwatch,dynamodb,dynamodbstreams,lambda
+      SERVICES: cloudwatch,dynamodb,dynamodbstreams,lambda,iam
+      LAMBDA_DOCKER_NETWORK: ${LAMBDA_DOCKER_NETWORK:-cqrs-es-example-js_default}
+      MAIN_CONTAINER_NAME: localstack-main
       HOSTNAME_EXTERNAL: localstack-local
       DEFAULT_REGION: ap-northeast-1
       DYNAMODB_SHARE_DB: 1
       DYNAMODB_IN_MEMORY: 1
-      # LAMBDA_PREBUILD_IMAGES: 1
-      # LAMBDA_EXECUTOR: docker
-      # LAMBDA_RUNTIME_EXECUTOR: docker
-      # LAMBDA_REMOTE_DOCKER: true
-      # LAMBDA_REMOVE_CONTAINERS: true
-      # DATA_DIR: /tmp/localstack/data
-      # DOCKER_HOST: unix:///var/run/docker.sock
-      # LAMBDA_DOCKER_FLAGS: --platform linux/amd64
-    # privileged: true
+      LAMBDA_EXECUTOR: docker
+      LAMBDA_REMOVE_CONTAINERS: 1
+      LAMBDA_DOCKER_FLAGS: --platform linux/amd64
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -81,6 +74,7 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: x
       AWS_SECRET_ACCESS_KEY: x
+      AWS_REGION: ap-northeast-1
       AWS_DEFAULT_REGION: ap-northeast-1
       DYNAMODB_ENDPOINT: localstack:4566
       JOURNAL_TABLE_NAME: journal

--- a/tools/docker-compose/docker-compose-e2e-test.yml
+++ b/tools/docker-compose/docker-compose-e2e-test.yml
@@ -1,7 +1,13 @@
 version: '3.6'
 services:
   e2e-test:
+    profiles:
+      - e2e
     image: e2e-test-js:latest
+    # イメージ内の焼き込みではなく、常にリポジトリ上のスクリプトを使う（待機ロジック等の変更が即反映される）
+    volumes:
+      - ../e2e-test/verify-group-chat.sh:/verify-group-chat.sh:ro
+    entrypoint: ["bash", "/verify-group-chat.sh"]
     environment:
       WRITE_API_SERVER_BASE_URL: http://write-api-server-1:3000
       READ_API_SERVER_BASE_URL: http://read-api-server-1:3000

--- a/tools/e2e-test/verify-group-chat.sh
+++ b/tools/e2e-test/verify-group-chat.sh
@@ -7,10 +7,66 @@ USER_ACCOUNT_ID=${USER_ACCOUNT_ID:-UserAccount-01H7C6DWMK1BKS1JYH1XZE529M}
 WRITE_API_SERVER_BASE_URL=${WRITE_API_SERVER_BASE_URL:-http://localhost:38080}
 READ_API_SERVER_BASE_URL=${READ_API_SERVER_BASE_URL:-http://localhost:38082}
 
+# GraphQL の listen 待ち（短めでよい）
+WAIT_GRAPHQL_ATTEMPTS=${WAIT_GRAPHQL_ATTEMPTS:-45}
+WAIT_GRAPHQL_SLEEP_SEC=${WAIT_GRAPHQL_SLEEP_SEC:-1}
+# Lambda RMU → MySQL 投影は遅れうる。60×1s に縮めるとタイムアウトしやすいので 90×2s を既定のまま
+WAIT_READ_MODEL_ATTEMPTS=${WAIT_READ_MODEL_ATTEMPTS:-90}
+WAIT_READ_MODEL_SLEEP_SEC=${WAIT_READ_MODEL_SLEEP_SEC:-2}
+
+# Compose 直後は API がまだ listen していないことがある（ホスト／コンテナ共通）
+wait_for_graphql() {
+  local base_url=$1
+  local label=$2
+  local i
+  for i in $(seq 1 "${WAIT_GRAPHQL_ATTEMPTS}"); do
+    # set -e でも接続失敗でループを継続する（curl は失敗時に非ゼロを返す）
+    code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${base_url}/" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"{ __typename }"}') || true
+    if [ "$code" = "200" ]; then
+      echo "Ready: ${label} (${base_url})"
+      return 0
+    fi
+    sleep "${WAIT_GRAPHQL_SLEEP_SEC}"
+  done
+  echo "Timeout waiting for ${label} at ${base_url}" >&2
+  exit 1
+}
+
+# DynamoDB ストリーム → Lambda RMU → MySQL 投影までの遅延を吸収する（GROUP_CHAT_ID / ADMIN_ID が設定済みであること）
+wait_for_read_model_group_chat() {
+  local expect_name="${1:-}"
+  local i
+  local r
+  for i in $(seq 1 "${WAIT_READ_MODEL_ATTEMPTS}"); do
+    r=$(curl -s -X POST -H "Content-Type: application/json" \
+      "${READ_API_SERVER_BASE_URL}/" \
+      -d "{\"query\": \"{ getGroupChat(groupChatId: \\\"${GROUP_CHAT_ID}\\\", userAccountId: \\\"${ADMIN_ID}\\\") { id name } }\"}") || true
+
+    if echo "$r" | jq -e '.data.getGroupChat != null' >/dev/null 2>&1; then
+      if [ -z "$expect_name" ] || echo "$r" | jq -e --arg n "$expect_name" '.data.getGroupChat.name == $n' >/dev/null 2>&1; then
+        if [ -n "$expect_name" ]; then
+          echo "Read model OK (name=${expect_name})"
+        else
+          echo "Read model OK (group chat visible)"
+        fi
+        return 0
+      fi
+    fi
+    sleep "${WAIT_READ_MODEL_SLEEP_SEC}"
+  done
+  echo "Timeout waiting for read model (getGroupChat${expect_name:+ name=${expect_name}})" >&2
+  exit 1
+}
+
+wait_for_graphql "${WRITE_API_SERVER_BASE_URL}" "write-api"
+wait_for_graphql "${READ_API_SERVER_BASE_URL}" "read-api"
+
 # グループチャット作成
 echo -e "\nCreate GroupChat(${ADMIN_ID}):"
 CREATE_GROUP_CHAT_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${WRITE_API_SERVER_BASE_URL}/query \
+	${WRITE_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 {
   "query": "mutation CreateGroupChat(\$input: CreateGroupChatInput!) { createGroupChat(input: \$input) { groupChatId } }",
@@ -36,7 +92,7 @@ GROUP_CHAT_ID=$(echo $CREATE_GROUP_CHAT_RESULT | jq -r .data.createGroupChat.gro
 # メンバー追加
 echo -e "\nAdd Member(${GROUP_CHAT_ID}, ${USER_ACCOUNT_ID}, ${ADMIN_ID}):"
 ADD_MEMBER_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${WRITE_API_SERVER_BASE_URL}/query \
+	${WRITE_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 {
   "query": "mutation AddMember(\$input: AddMemberInput!) { addMember(input: \$input) { groupChatId } }",
@@ -62,7 +118,7 @@ echo "Result: $ADD_MEMBER_RESULT"
 # メッセージ投稿
 echo -e "\nPost Message(${GROUP_CHAT_ID}, ${USER_ACCOUNT_ID}):"
 POST_MESSAGE_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${WRITE_API_SERVER_BASE_URL}/query \
+	${WRITE_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 {
   "query": "mutation PostMessage(\$input: PostMessageInput!) { postMessage(input: \$input) { groupChatId, messageId } }",
@@ -86,12 +142,12 @@ echo "Result: $POST_MESSAGE_RESULT"
 
 MESSAGE_ID=$(echo $POST_MESSAGE_RESULT | jq -r .data.postMessage.messageId)
 
-sleep 1
+wait_for_read_model_group_chat ""
 
 # グループチャット取得
 echo -e "\nGet GroupChat(${GROUP_CHAT_ID}, ${ADMIN_ID}):"
 GET_GROUP_CHAT_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${READ_API_SERVER_BASE_URL}/query \
+	${READ_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 { "query": "{ getGroupChat(groupChatId: \"${GROUP_CHAT_ID}\", userAccountId: \"${ADMIN_ID}\") { id, name, ownerId, createdAt, updatedAt } }" }
 EOS
@@ -107,7 +163,7 @@ echo "Result: $GET_GROUP_CHAT_RESULT"
 # グループチャットリスト取得
 echo -e "\nGet GroupChats(${ADMIN_ID}):"
 GET_GROUP_CHATS_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${READ_API_SERVER_BASE_URL}/query \
+	${READ_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 { "query": "{ getGroupChats(userAccountId: \"${ADMIN_ID}\") { id, name, ownerId, createdAt, updatedAt } }" }
 EOS
@@ -123,7 +179,7 @@ echo "Result: $GET_GROUP_CHATS_RESULT"
 # グループチャット名の変更
 echo -e "\nRename GroupChat(${GROUP_CHAT_ID}, ${ADMIN_ID}):"
 RENAME_GROUP_CHAT_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${WRITE_API_SERVER_BASE_URL}/query \
+	${WRITE_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 {
   "query": "mutation RenameGroupChat(\$input: RenameGroupChatInput!) { renameGroupChat(input: \$input) { groupChatId } }",
@@ -145,12 +201,12 @@ fi
 
 echo "Result: $RENAME_GROUP_CHAT_RESULT"
 
-sleep 1
+wait_for_read_model_group_chat "group-chat-example-2"
 
 # グループチャット取得
 echo -e "\nGet GroupChat(${GROUP_CHAT_ID}, ${ADMIN_ID}):"
 GET_GROUP_CHAT_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${READ_API_SERVER_BASE_URL}/query \
+	${READ_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 { "query": "{ getGroupChat(groupChatId: \"${GROUP_CHAT_ID}\", userAccountId: \"${ADMIN_ID}\") { id, name, ownerId, createdAt, updatedAt } }" }
 EOS
@@ -166,7 +222,7 @@ echo "Result: $GET_GROUP_CHAT_RESULT"
 # メンバー取得
 echo -e "\nGet Member(${GROUP_CHAT_ID}, ${USER_ACCOUNT_ID}):"
 GET_MEMBER_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${READ_API_SERVER_BASE_URL}/query \
+	${READ_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 { "query": "{ getMember(groupChatId: \"${GROUP_CHAT_ID}\", userAccountId: \"${USER_ACCOUNT_ID}\") { id, groupChatId, userAccountId, role, createdAt, updatedAt } }" }
 EOS
@@ -182,7 +238,7 @@ echo "Result: $GET_MEMBER_RESULT"
 # メンバーリスト取得
 echo -e "\nGet Members(${GROUP_CHAT_ID}, ${USER_ACCOUNT_ID}):"
 GET_MEMBERS_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${READ_API_SERVER_BASE_URL}/query \
+	${READ_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 { "query": "{ getMembers(groupChatId: \"${GROUP_CHAT_ID}\", userAccountId: \"${USER_ACCOUNT_ID}\") { id, groupChatId, userAccountId, role, createdAt, updatedAt } }" }
 EOS
@@ -198,7 +254,7 @@ echo "Result: $GET_MEMBERS_RESULT"
 # メッセージ取得
 echo -e "\nGet Message(${MESSAGE_ID}, ${USER_ACCOUNT_ID}):"
 GET_MESSAGE_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${READ_API_SERVER_BASE_URL}/query \
+	${READ_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 { "query": "{ getMessage(messageId: \"${MESSAGE_ID}\", userAccountId: \"${USER_ACCOUNT_ID}\") { id, groupChatId, text, createdAt, updatedAt } }" }
 EOS
@@ -214,7 +270,7 @@ echo "Result: $GET_MESSAGE_RESULT"
 # メッセージリスト取得
 echo -e "\nGet Messages(${GROUP_CHAT_ID}, ${USER_ACCOUNT_ID}):"
 GET_MESSAGES_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${READ_API_SERVER_BASE_URL}/query \
+	${READ_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 { "query": "{ getMessages(groupChatId: \"${GROUP_CHAT_ID}\", userAccountId: \"${USER_ACCOUNT_ID}\") { id, groupChatId, text, createdAt, updatedAt } }" }
 EOS
@@ -230,7 +286,7 @@ echo "Result: $GET_MESSAGES_RESULT"
 # メッセージの削除
 echo -e "\nDelete Message(${GROUP_CHAT_ID}, ${MESSAGE_ID}, ${USER_ACCOUNT_ID}):"
 DELETE_MESSAGE_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${WRITE_API_SERVER_BASE_URL}/query \
+	${WRITE_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 {
   "query": "mutation DeleteMessage(\$input: DeleteMessageInput!) { deleteMessage(input: \$input) { groupChatId } }",
@@ -255,7 +311,7 @@ echo "Result: $DELETE_MESSAGE_RESULT"
 # メンバーの削除
 echo -e "\nRemove Member(${GROUP_CHAT_ID}, ${USER_ACCOUNT_ID}, ${ADMIN_ID}):"
 REMOVE_MEMBER_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${WRITE_API_SERVER_BASE_URL}/query \
+	${WRITE_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 {
   "query": "mutation RemoveMember(\$input: RemoveMemberInput!) { removeMember(input: \$input) { groupChatId } }",
@@ -280,7 +336,7 @@ echo "Result: $REMOVE_MEMBER_RESULT"
 # ルームの削除
 echo -e "\nDelete GroupChat(${GROUP_CHAT_ID}, ${ADMIN_ID}):"
 DELETE_GROUP_CHAT_RESULT=$(curl -s -X POST -H "Content-Type: application/json" \
-	${WRITE_API_SERVER_BASE_URL}/query \
+	${WRITE_API_SERVER_BASE_URL}/ \
 	-d @- <<EOS
 {
   "query": "mutation DeleteGroupChat(\$input: DeleteGroupChatInput!) { deleteGroupChat(input: \$input) { groupChatId } }",

--- a/tools/scripts/build-read-model-updater-lambda.docker-inner.sh
+++ b/tools/scripts/build-read-model-updater-lambda.docker-inner.sh
@@ -1,34 +1,43 @@
 #!/usr/bin/env bash
 # Run inside Docker (linux/amd64) — invoked by build-read-model-updater-lambda.sh
+#
+# /workspace is a bind-mount of the host repo. To avoid overwriting host
+# node_modules with Linux-specific binaries, we copy the source tree to
+# /build and perform all work there. Only the final zip is written back
+# to /workspace/dist/.
 set -euo pipefail
-
-cd /workspace
 
 export CI=true
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get install -y -qq zip
+apt-get install -y -qq zip rsync
 
 corepack enable && corepack prepare pnpm@9.15.9 --activate
+
+# --- Copy source to isolated build directory ---
+BUILD=/build
+rm -rf "${BUILD}"
+rsync -a --exclude node_modules --exclude .turbo --exclude dist /workspace/ "${BUILD}/"
+cd "${BUILD}"
 
 pnpm install --frozen-lockfile
 pnpm prisma:generate
 pnpm exec turbo build --filter=cqrs-es-example-js-rmu --filter=cqrs-es-example-js-bootstrap
 
-STAGE="/workspace/dist/lambda/read-model-updater/stage"
-ZIP="/workspace/dist/lambda/read-model-updater/function.zip"
-rm -rf "${STAGE}" "${ZIP}"
+STAGE="${BUILD}/dist/lambda/read-model-updater/stage"
+ZIP_TMP="${BUILD}/dist/lambda/read-model-updater/function.zip"
+rm -rf "${STAGE}" "${ZIP_TMP}"
 mkdir -p "${STAGE}/node_modules"
 
-pnpm dlx esbuild@0.25.0 /workspace/packages/bootstrap/src/lambda-rmu-handler.ts \
+pnpm dlx esbuild@0.25.0 "${BUILD}/packages/bootstrap/src/lambda-rmu-handler.ts" \
   --bundle \
   --platform=node \
   --target=node18 \
   --outfile="${STAGE}/index.js" \
   --external:@prisma/client
 
-NM="$(node -p "const p=require('path');const x=require.resolve('@prisma/client/package.json',{paths:['/workspace/packages/bootstrap']});p.join(p.dirname(x),'..','..')")"
+NM="$(node -p "const p=require('path');const x=require.resolve('@prisma/client/package.json',{paths:['${BUILD}/packages/bootstrap']});p.join(p.dirname(x),'..','..')")"
 cp -r "${NM}/@prisma" "${STAGE}/node_modules/"
 cp -r "${NM}/.prisma" "${STAGE}/node_modules/"
 
@@ -39,7 +48,12 @@ find "${STAGE}/node_modules" -name "introspection-engine-*" -delete 2>/dev/null 
 find "${STAGE}/node_modules" -name "migration-engine-*" -delete 2>/dev/null || true
 
 cd "${STAGE}"
-zip -q -r "${ZIP}" .
+zip -q -r "${ZIP_TMP}" .
 
-echo "Wrote ${ZIP}"
-ls -la "${ZIP}"
+# --- Write only the final artifact back to the host mount ---
+OUT_DIR="/workspace/dist/lambda/read-model-updater"
+mkdir -p "${OUT_DIR}"
+cp "${ZIP_TMP}" "${OUT_DIR}/function.zip"
+
+echo "Wrote ${OUT_DIR}/function.zip"
+ls -la "${OUT_DIR}/function.zip"

--- a/tools/scripts/build-read-model-updater-lambda.docker-inner.sh
+++ b/tools/scripts/build-read-model-updater-lambda.docker-inner.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run inside Docker (linux/amd64) — invoked by build-read-model-updater-lambda.sh
+set -euo pipefail
+
+cd /workspace
+
+export CI=true
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq zip
+
+corepack enable && corepack prepare pnpm@9.15.9 --activate
+
+pnpm install --frozen-lockfile
+pnpm prisma:generate
+pnpm exec turbo build --filter=cqrs-es-example-js-rmu --filter=cqrs-es-example-js-bootstrap
+
+STAGE="/workspace/dist/lambda/read-model-updater/stage"
+ZIP="/workspace/dist/lambda/read-model-updater/function.zip"
+rm -rf "${STAGE}" "${ZIP}"
+mkdir -p "${STAGE}/node_modules"
+
+pnpm dlx esbuild@0.25.0 /workspace/packages/bootstrap/src/lambda-rmu-handler.ts \
+  --bundle \
+  --platform=node \
+  --target=node18 \
+  --outfile="${STAGE}/index.js" \
+  --external:@prisma/client
+
+NM="$(node -p "const p=require('path');const x=require.resolve('@prisma/client/package.json',{paths:['/workspace/packages/bootstrap']});p.join(p.dirname(x),'..','..')")"
+cp -r "${NM}/@prisma" "${STAGE}/node_modules/"
+cp -r "${NM}/.prisma" "${STAGE}/node_modules/"
+
+# Lambda (Amazon Linux 2) に不要な Prisma ネイティブバイナリを除去してサイズ削減
+find "${STAGE}/node_modules" -name "libquery_engine-*" -not -name "*rhel-openssl-1.0.x*" -delete
+find "${STAGE}/node_modules" -name "schema-engine-*" -delete 2>/dev/null || true
+find "${STAGE}/node_modules" -name "introspection-engine-*" -delete 2>/dev/null || true
+find "${STAGE}/node_modules" -name "migration-engine-*" -delete 2>/dev/null || true
+
+cd "${STAGE}"
+zip -q -r "${ZIP}" .
+
+echo "Wrote ${ZIP}"
+ls -la "${ZIP}"

--- a/tools/scripts/build-read-model-updater-lambda.sh
+++ b/tools/scripts/build-read-model-updater-lambda.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "${ROOT}"
+
+IMAGE="${LAMBDA_BUILD_IMAGE:-node:22-bookworm}"
+
+docker run --rm --platform linux/amd64 \
+  -v "${ROOT}:/workspace" -w /workspace \
+  "${IMAGE}" \
+  bash /workspace/tools/scripts/build-read-model-updater-lambda.docker-inner.sh

--- a/tools/scripts/deploy-read-model-updater-localstack.sh
+++ b/tools/scripts/deploy-read-model-updater-localstack.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "${ROOT}"
+
+ZIP="${ROOT}/dist/lambda/read-model-updater/function.zip"
+if [ ! -f "${ZIP}" ]; then
+  echo "Missing ${ZIP}. Run: pnpm build-read-model-updater-lambda" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+[ -f "${ROOT}/common.env" ] && set -a && source "${ROOT}/common.env" && set +a
+
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-x}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-x}"
+export AWS_DEFAULT_REGION="${AWS_REGION:-ap-northeast-1}"
+
+LOCALSTACK_ENDPOINT_URL="${LOCALSTACK_ENDPOINT_URL:-http://localhost:34566}"
+FUNCTION_NAME="${FUNCTION_NAME:-read-model-updater-rmu}"
+STREAM_JOURNAL_TABLE_NAME="${STREAM_JOURNAL_TABLE_NAME:-journal}"
+ROLE_ARN="${LAMBDA_ROLE_ARN:-arn:aws:iam::000000000000:role/lambda-role}"
+# LocalStack 2.x community image may not list nodejs20.x; use nodejs18.x unless overridden.
+RUNTIME="${LAMBDA_RUNTIME:-nodejs18.x}"
+
+DATABASE_URL_LAMBDA="${DATABASE_URL_LAMBDA:-mysql://ceer:ceer@mysql-local:3306/ceer}"
+STREAM_MAX_ITEM_COUNT="${STREAM_MAX_ITEM_COUNT:-32}"
+
+wait_for_localstack() {
+  local i
+  for i in $(seq 1 90); do
+    if aws dynamodb list-tables \
+      --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+      --region "${AWS_DEFAULT_REGION}" \
+      >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "LocalStack did not become ready at ${LOCALSTACK_ENDPOINT_URL}" >&2
+  return 1
+}
+
+wait_for_localstack
+
+if ! aws iam get-role \
+  --role-name lambda-role \
+  --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+  --region "${AWS_DEFAULT_REGION}" \
+  >/dev/null 2>&1; then
+  aws iam create-role \
+    --role-name lambda-role \
+    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+    --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+    --region "${AWS_DEFAULT_REGION}" \
+    >/dev/null 2>&1 || true
+fi
+
+STREAM_ARN="$(aws dynamodb describe-table \
+  --table-name "${STREAM_JOURNAL_TABLE_NAME}" \
+  --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+  --region "${AWS_DEFAULT_REGION}" \
+  --query 'Table.LatestStreamArn' \
+  --output text)"
+
+if [ "${STREAM_ARN}" = "None" ] || [ -z "${STREAM_ARN}" ]; then
+  echo "Could not read DynamoDB stream ARN for table ${STREAM_JOURNAL_TABLE_NAME}" >&2
+  exit 1
+fi
+
+ENV_FILE="$(mktemp)"
+trap 'rm -f "${ENV_FILE}"' EXIT
+
+python3 - <<PY > "${ENV_FILE}"
+import json
+print(json.dumps({
+  "Variables": {
+    "DATABASE_URL": "${DATABASE_URL_LAMBDA}",
+    "AWS_REGION": "${AWS_DEFAULT_REGION}",
+    "AWS_DYNAMODB_ENDPOINT_URL": "http://localstack:4566",
+    "AWS_DYNAMODB_ACCESS_KEY_ID": "${AWS_ACCESS_KEY_ID}",
+    "AWS_DYNAMODB_SECRET_ACCESS_KEY": "${AWS_SECRET_ACCESS_KEY}",
+    "STREAM_JOURNAL_TABLE_NAME": "${STREAM_JOURNAL_TABLE_NAME}",
+    "STREAM_MAX_ITEM_COUNT": "${STREAM_MAX_ITEM_COUNT}",
+  }
+}))
+PY
+
+create_or_update_function() {
+  set +e
+  aws lambda get-function \
+    --function-name "${FUNCTION_NAME}" \
+    --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+    --region "${AWS_DEFAULT_REGION}" \
+    >/dev/null 2>&1
+  local exists=$?
+  set -e
+
+  if [ "${exists}" -ne 0 ]; then
+    aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime "${RUNTIME}" \
+      --handler index.handler \
+      --role "${ROLE_ARN}" \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 120 \
+      --memory-size 512 \
+      --environment "file://${ENV_FILE}" \
+      --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+      --region "${AWS_DEFAULT_REGION}"
+  else
+    aws lambda update-function-code \
+      --function-name "${FUNCTION_NAME}" \
+      --zip-file "fileb://${ZIP}" \
+      --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+      --region "${AWS_DEFAULT_REGION}"
+    aws lambda update-function-configuration \
+      --function-name "${FUNCTION_NAME}" \
+      --environment "file://${ENV_FILE}" \
+      --timeout 120 \
+      --memory-size 512 \
+      --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+      --region "${AWS_DEFAULT_REGION}"
+  fi
+}
+
+create_or_update_function
+
+# Lambda が Active になるまで待機
+wait_for_lambda_active() {
+  local i
+  for i in $(seq 1 60); do
+    local state
+    state=$(aws lambda get-function \
+      --function-name "${FUNCTION_NAME}" \
+      --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+      --region "${AWS_DEFAULT_REGION}" \
+      --query 'Configuration.State' \
+      --output text 2>/dev/null) || true
+    if [ "${state}" = "Active" ]; then
+      echo "Lambda ${FUNCTION_NAME} is Active"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timeout waiting for Lambda ${FUNCTION_NAME} to become Active" >&2
+  return 1
+}
+
+wait_for_lambda_active
+
+# Event source mapping (idempotent: delete existing for this function + stream if any)
+while read -r uuid; do
+  [ -z "${uuid}" ] && continue
+  aws lambda delete-event-source-mapping \
+    --uuid "${uuid}" \
+    --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+    --region "${AWS_DEFAULT_REGION}" \
+    >/dev/null 2>&1 || true
+done < <(aws lambda list-event-source-mappings \
+  --function-name "${FUNCTION_NAME}" \
+  --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+  --region "${AWS_DEFAULT_REGION}" \
+  --query 'EventSourceMappings[].UUID' \
+  --output text 2>/dev/null | tr '\t' '\n')
+
+# DynamoDB Stream が利用可能になるまでリトライ
+create_event_source_mapping() {
+  local i
+  for i in $(seq 1 30); do
+    ESM_OUTPUT=$(aws lambda create-event-source-mapping \
+      --function-name "${FUNCTION_NAME}" \
+      --event-source-arn "${STREAM_ARN}" \
+      --batch-size 10 \
+      --starting-position TRIM_HORIZON \
+      --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+      --region "${AWS_DEFAULT_REGION}" 2>&1) && break
+    echo "Waiting for DynamoDB stream to become available (attempt ${i}/30)..." >&2
+    sleep 2
+  done
+  echo "${ESM_OUTPUT}"
+}
+
+ESM_OUTPUT=$(create_event_source_mapping)
+
+ESM_UUID=$(echo "${ESM_OUTPUT}" | python3 -c "import sys,json; print(json.load(sys.stdin)['UUID'])")
+
+# Event Source Mapping が Enabled になるまで待機
+wait_for_esm_enabled() {
+  local i
+  for i in $(seq 1 60); do
+    local state
+    state=$(aws lambda get-event-source-mapping \
+      --uuid "${ESM_UUID}" \
+      --endpoint-url "${LOCALSTACK_ENDPOINT_URL}" \
+      --region "${AWS_DEFAULT_REGION}" \
+      --query 'State' \
+      --output text 2>/dev/null) || true
+    if [ "${state}" = "Enabled" ]; then
+      echo "Event source mapping ${ESM_UUID} is Enabled"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timeout waiting for event source mapping to become Enabled" >&2
+  return 1
+}
+
+wait_for_esm_enabled
+
+if [ "${STOP_LOCAL_RMU_AFTER_LAMBDA_DEPLOY:-1}" != "0" ]; then
+  COMPOSE_PROJECT="${COMPOSE_PROJECT:-cqrs-es-example-js}"
+  COMPOSE_FILES=(
+    -f "${ROOT}/tools/docker-compose/docker-compose-databases.yml"
+    -f "${ROOT}/tools/docker-compose/docker-compose-applications.yml"
+  )
+  docker compose -p "${COMPOSE_PROJECT}" "${COMPOSE_FILES[@]}" stop read-model-updater-1 || true
+fi
+
+echo "Deployed Lambda ${FUNCTION_NAME} with stream ${STREAM_ARN}"

--- a/tools/scripts/docker-compose-e2e-test.sh
+++ b/tools/scripts/docker-compose-e2e-test.sh
@@ -2,8 +2,25 @@
 
 set -eu
 
-# shellcheck disable=SC2046
-cd $(dirname "$0") || exit
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${SCRIPT_DIR}" || exit
+
+if [ -f "${ROOT}/common.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT}/common.env"
+  set +a
+elif [ -f "${ROOT}/common.env.default" ]; then
+  cp "${ROOT}/common.env.default" "${ROOT}/common.env"
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT}/common.env"
+  set +a
+fi
+
+export LOCALSTACK_ENDPOINT_URL="${LOCALSTACK_ENDPOINT_URL:-http://localhost:34566}"
 
 export ARCH=$(uname -m)
 echo "ARCH=${ARCH}"
@@ -17,16 +34,39 @@ if [ "$ARCH" = "aarch64" ]; then
 fi
 
 F_OPTION="-f ../docker-compose/docker-compose-applications.yml -f ../docker-compose/docker-compose-e2e-test.yml"
+# pnpm は `script -- -l` のように先頭に `--` を付ける。getopts は `--` で止まるため除去する
+while [ $# -gt 0 ] && [ "$1" = "--" ]; do
+  shift
+done
 
-while getopts d OPT; do
+SKIP_LAMBDA_BUILD=0
+while getopts dl OPT; do
   # shellcheck disable=SC2220
   case ${OPT} in
   "d") F_OPTION="" ;;
+  "l") SKIP_LAMBDA_BUILD=1 ;;
   esac
 done
 
 # Remove processed options from $@
 shift $(($OPTIND - 1))
 
+if [ "${SKIP_LAMBDA_BUILD}" != "1" ] && [ "${DOCKER_COMPOSE_UP_BUILD_LAMBDA:-1}" != "0" ]; then
+  (cd "${ROOT}" && ./tools/scripts/build-read-model-updater-lambda.sh)
+fi
+
 docker compose -p cqrs-es-example-js -f ../docker-compose/docker-compose-databases.yml ${F_OPTION} down -v --remove-orphans
+# e2e-test は profile `e2e` のためここでは起動しない（アプリと DB の準備 → Lambda デプロイ → その後に検証）
 docker compose -p cqrs-es-example-js -f ../docker-compose/docker-compose-databases.yml ${F_OPTION} up --remove-orphans --force-recreate --renew-anon-volumes -d "$@"
+
+if [ "${DOCKER_COMPOSE_UP_DEPLOY_LAMBDA:-1}" != "0" ]; then
+  if command -v aws >/dev/null 2>&1; then
+    (cd "${ROOT}" && ./tools/scripts/deploy-read-model-updater-localstack.sh)
+  else
+    echo "Skipping Lambda deploy to LocalStack: aws CLI not found. Install it or set DOCKER_COMPOSE_UP_DEPLOY_LAMBDA=0." >&2
+  fi
+fi
+
+# GraphQL API が応答してから E2E（compose run はデプロイ後に一度だけ実行）
+# --no-deps: depends_on のサービスを再度起動しない（run 時に write/read が再起動すると接続に失敗する）
+docker compose -p cqrs-es-example-js -f ../docker-compose/docker-compose-databases.yml ${F_OPTION} --profile e2e run --no-deps --rm e2e-test

--- a/tools/scripts/docker-compose-up.sh
+++ b/tools/scripts/docker-compose-up.sh
@@ -2,8 +2,33 @@
 
 set -eu
 
-# shellcheck disable=SC2046
-cd $(dirname "$0") || exit
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${SCRIPT_DIR}" || exit
+
+if [ -f "${ROOT}/common.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT}/common.env"
+  set +a
+elif [ -f "${ROOT}/common.env.default" ]; then
+  cp "${ROOT}/common.env.default" "${ROOT}/common.env"
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT}/common.env"
+  set +a
+fi
+
+export LOCALSTACK_ENDPOINT_URL="${LOCALSTACK_ENDPOINT_URL:-http://localhost:34566}"
+
+if [ "${DOCKER_COMPOSE_UP_BUILD_LAMBDA:-1}" != "0" ]; then
+  if [ ! -f "${ROOT}/dist/lambda/read-model-updater/function.zip" ] || \
+     [ "${ROOT}/packages/bootstrap/src/lambda-rmu-handler.ts" -nt "${ROOT}/dist/lambda/read-model-updater/function.zip" ] || \
+     [ "${ROOT}/packages/rmu/prisma/schema.prisma" -nt "${ROOT}/dist/lambda/read-model-updater/function.zip" ]; then
+    (cd "${ROOT}" && ./tools/scripts/build-read-model-updater-lambda.sh)
+  fi
+fi
 
 export ARCH=$(uname -m)
 echo "ARCH=${ARCH}"
@@ -31,3 +56,11 @@ shift $(($OPTIND - 1))
 docker compose -p cqrs-es-example-js -f ../docker-compose/docker-compose-databases.yml ${F_OPTION} down -v --remove-orphans
 # docker compose -p cqrs-es-example-go -f ../docker-compose/docker-compose-databases.yml ${F_OPTION} build --no-cache
 docker compose -p cqrs-es-example-js -f ../docker-compose/docker-compose-databases.yml ${F_OPTION} up --remove-orphans --force-recreate --renew-anon-volumes -d "$@"
+
+if [ "${DOCKER_COMPOSE_UP_DEPLOY_LAMBDA:-1}" != "0" ]; then
+  if command -v aws >/dev/null 2>&1; then
+    (cd "${ROOT}" && ./tools/scripts/deploy-read-model-updater-localstack.sh)
+  else
+    echo "Skipping Lambda deploy to LocalStack: aws CLI not found. Install it or set DOCKER_COMPOSE_UP_DEPLOY_LAMBDA=0." >&2
+  fi
+fi


### PR DESCRIPTION
## Summary

- LocalStack上でLambdaベースのRead Model Updater（RMU）をDynamoDB Streams経由で動作させるための修正
- Lambda ビルド/デプロイスクリプト、ハンドラーの追加
- E2Eテストフローを Lambda デプロイ → DynamoDB Streams トリガー → リードモデル検証に更新

## Changes

### Lambda infrastructure
- `packages/bootstrap/src/lambda-rmu-handler.ts`: Lambda handler entry point
- `tools/scripts/build-read-model-updater-lambda.sh`: esbuild + Prisma native binaries をZIPにパッケージ
- `tools/scripts/build-read-model-updater-lambda.docker-inner.sh`: linux/amd64 Docker内ビルド、不要なPrismaバイナリを除去
- `tools/scripts/deploy-read-model-updater-localstack.sh`: Lambda作成/更新、ESM作成、Active/Enabled待機

### LocalStack configuration
- `LAMBDA_EXECUTOR: docker`, `MAIN_CONTAINER_NAME`, `LAMBDA_DOCKER_NETWORK` を追加（Docker Desktop上のLambdaコンテナネットワーク問題を解決）
- `lambda`, `iam` をSERVICESに追加
- `AWS_REGION` を dynamodb-setup に追加（リージョン不一致を修正）

### RMU payload decoding fix
- LocalStack の DynamoDB Stream イベントでは B フィールドに生JSON文字列が入る（Base64ではなく）
- 3パターン対応: 生JSON（LocalStack）、Base64（AWS Lambda）、カンマ区切り数値（ローカルRMU）
- Prisma `binaryTargets` に `rhel-openssl-1.0.x` を追加（Amazon Linux 2 Lambda runtime用）

## Test plan

- [x] E2Eテスト（`docker-compose-e2e-test.sh -l`）がLocalStack Lambda経由で全項目パス
  - CreateGroupChat → AddMember → PostMessage → リードモデル反映確認
  - RenameGroupChat → リードモデル反映確認
  - GetGroupChat / GetGroupChats / GetMember / GetMembers / GetMessage / GetMessages
  - DeleteMessage → RemoveMember → DeleteGroupChat

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the read-model projection path and adds LocalStack Lambda build/deploy automation, which can affect event decoding/projection correctness and CI reliability, but is scoped to LocalStack/dev workflows.
> 
> **Overview**
> **Enable Lambda-based RMU on LocalStack.** Adds a dedicated Lambda handler (`lambda-rmu-handler.ts`) plus new `pnpm` scripts and shell tooling to build a Linux/amd64 deployment zip (bundled with Prisma engines) and deploy it to LocalStack with IAM role + DynamoDB stream event-source mapping setup.
> 
> **Make LocalStack + E2E flow deterministic.** Updates Docker Compose LocalStack config to run `lambda`/`iam` with Docker executor/network settings, adjusts E2E compose to run the test container via a profile after Lambda deploy, and hardens `verify-group-chat.sh` with API/read-model polling to wait for stream→Lambda→MySQL projection.
> 
> **Fix RMU stream payload decoding across environments.** `update-read-model.ts` now handles three `payload.B` formats (raw JSON from LocalStack, base64 from AWS Lambda, and comma-separated bytes from local RMU), and Prisma `binaryTargets` are expanded for Lambda compatibility. CI installs AWS CLI v2, and `common.env` is introduced (gitignored) with defaults documented in BUILD/TEST docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8452498d8bddf9cd836b1ec1ab32388a90a29168. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->