### PR TITLE
docs: propose Spanner backend local emulation

### DIFF
--- a/openspec/changes/support-spanner-backend-local-emulation/.openspec.yaml
+++ b/openspec/changes/support-spanner-backend-local-emulation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/support-spanner-backend-local-emulation/README.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/README.md
@@ -1,0 +1,3 @@
+# support-spanner-backend-local-emulation
+
+Plan event-store-adapter-js 3.0.0 upgrade with DynamoDB and Spanner backend parity, including local emulation for Spanner Change Streams to Pub/Sub to RMU.

--- a/openspec/changes/support-spanner-backend-local-emulation/design.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The current application is wired around DynamoDB as the event-store backend. The write API creates an `EventStoreFactory.ofDynamoDB(...)` instance, the RMU consumes DynamoDB stream records, and local end-to-end verification relies on LocalStack Lambda or a local RMU process to update the MySQL read model.
+
+`event-store-adapter-js` 3.0.0 changes the public API to `EventStore.ofDynamoDB(input)` and adds `EventStore.ofSpanner(input)`. Spanner support is only meaningful for this example if it demonstrates the same write-model to read-model flow as the DynamoDB version.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep a single application/package layout and select the event-store backend at runtime.
+- Maintain DynamoDB behavior and local verification.
+- Add a Spanner backend that reaches the MySQL read model through an asynchronous event stream.
+- Make the Spanner local path realistic enough to verify the same integration contract as production.
+- Keep RMU business logic provider-neutral.
+
+**Non-Goals:**
+
+- Do not split the application into backend-specific packages.
+- Do not use a poller as the accepted Spanner architecture if it bypasses the Change Streams/Pub/Sub contract.
+- Do not require managed Dataflow for local development.
+- Do not adopt Spanner Queue for this change; it requires adapter-level queue send support and is not the selected path.
+
+## Decisions
+
+### Backend Selection
+
+Use a runtime environment variable such as `PERSISTENCE_BACKEND=dynamodb|spanner`.
+
+- `dynamodb` constructs `EventStore.ofDynamoDB({ ... })`.
+- `spanner` constructs `EventStore.ofSpanner({ ... })`.
+- Existing domain, command processor, repository, and GraphQL wiring remain shared.
+
+This keeps the example focused on backend substitution rather than duplicate application layouts.
+
+### DynamoDB RMU Path
+
+Keep the current AWS-compatible path:
+
+`LocalStack DynamoDB -> DynamoDB Streams -> LocalStack Lambda/localRmu -> MySQL`
+
+The current Lambda-style handler remains useful, but its event decoding should delegate to a shared RMU application service.
+
+### Spanner Production RMU Path
+
+Use the GCP path:
+
+`Spanner journal -> Spanner Change Streams -> Dataflow -> Pub/Sub -> Cloud Run functions / Cloud Functions -> MySQL`
+
+The Change Stream must watch `journal`, not `snapshot`, so only domain event inserts drive read-model updates.
+
+### Spanner Local RMU Path
+
+Use local emulators and a local bridge:
+
+`Spanner emulator -> local Change Stream bridge or Beam DirectRunner -> Pub/Sub emulator -> Functions Framework RMU -> MySQL`
+
+The local bridge is the replacement for managed Dataflow in development. It must preserve the Pub/Sub message contract consumed by the Functions Framework RMU. Pub/Sub emulator push subscriptions can deliver messages to an HTTP endpoint, which is the local equivalent of a Pub/Sub-triggered function.
+
+### RMU Core Shape
+
+Split RMU into:
+
+- provider-specific input adapters:
+  - DynamoDB Stream event adapter
+  - Pub/Sub/CloudEvent adapter
+- shared event application service:
+  - accepts decoded `GroupChatEvent` values
+  - applies them through `GroupChatDao`
+
+This avoids duplicating projection rules and makes retries/idempotency behavior easier to reason about.
+
+### Local Verification
+
+Both backend paths must support an end-to-end verification command that creates a group chat through the write API and confirms the read API observes the projected read model.
+
+For Spanner, the verification is valid only when the flow crosses the Pub/Sub/function boundary; a direct journal poller calling the DAO is not sufficient.
+
+## Risks / Trade-offs
+
+- Spanner emulator support for Change Streams must be validated early. If the emulator cannot execute the required `CREATE CHANGE STREAM` and `READ_<stream>` workflow, the local bridge cannot faithfully consume native Change Streams.
+- Managed Dataflow has no LocalStack-style emulator. A local Beam DirectRunner or bridge process is necessary, and it becomes part of the example's development infrastructure.
+- Pub/Sub and function delivery are at-least-once. The RMU must tolerate duplicate deliveries, using event identity such as aggregate id and sequence number where the read model needs idempotency.
+- Dataflow template payloads may not match the ideal RMU payload shape. The bridge/function adapter must define and document the accepted Pub/Sub message schema.

--- a/openspec/changes/support-spanner-backend-local-emulation/proposal.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`event-store-adapter-js` 3.0.0 adds Cloud Spanner support and changes the public construction API. This example project must demonstrate the updated library with both DynamoDB and Spanner while preserving the current CQRS/ES read-model flow, not only write-side persistence.
+
+## What Changes
+
+- Update the proposed runtime contract from a DynamoDB-only event store to a selectable `dynamodb` or `spanner` persistence backend.
+- Preserve the existing DynamoDB path with LocalStack DynamoDB Streams and the existing RMU behavior.
+- Add a Spanner path whose production architecture is `Spanner Change Streams -> Dataflow -> Pub/Sub -> Cloud Run functions / Cloud Functions -> MySQL read model`.
+- Add a local Spanner emulation path that verifies the same integration contract with `Spanner emulator -> local Change Stream bridge or Beam DirectRunner -> Pub/Sub emulator -> Functions Framework RMU -> MySQL`.
+- Refactor the RMU plan so event-application logic is shared and cloud-provider handlers are thin adapters.
+- Document startup and verification commands for both backends.
+
+## Capabilities
+
+### New Capabilities
+
+- `event-store-backend-selection`: Runtime selection and construction of DynamoDB and Spanner event stores using `event-store-adapter-js` 3.0.0.
+- `spanner-rmu-pipeline`: Spanner read-model update pipeline with production GCP topology and equivalent local emulation.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected packages: `packages/bootstrap`, `packages/rmu`, `packages/command/interface-adaptor-impl`, and integration scripts under `tools/`.
+- Affected infrastructure: LocalStack DynamoDB, Cloud Spanner emulator, Pub/Sub emulator, MySQL, Functions Framework, and a local Change Stream bridge or Beam DirectRunner process.
+- Affected documentation: build/test docs, local startup docs, and production architecture notes for the Spanner path.
+- Dependency impact: `event-store-adapter-js` 3.0.0, `@google-cloud/spanner`, Pub/Sub client/runtime dependencies, and Functions Framework dependencies where needed.

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Runtime backend selection
+The system SHALL allow the write API to select either the DynamoDB event-store backend or the Spanner event-store backend through runtime configuration without changing application packages.
+
+#### Scenario: DynamoDB backend selected
+- **WHEN** the write API starts with the DynamoDB backend selected
+- **THEN** it SHALL construct a DynamoDB event store using the `event-store-adapter-js` 3.0.0 object-input API
+- **AND** it SHALL preserve the existing DynamoDB table and stream configuration contract.
+
+#### Scenario: Spanner backend selected
+- **WHEN** the write API starts with the Spanner backend selected
+- **THEN** it SHALL construct a Spanner event store using the `event-store-adapter-js` 3.0.0 object-input API
+- **AND** it SHALL use caller-managed Spanner database configuration.
+
+### Requirement: Shared command application
+The system SHALL keep command-domain, command-processor, repository, and GraphQL behavior shared across DynamoDB and Spanner backends.
+
+#### Scenario: Same command flow across backends
+- **WHEN** a group chat command is executed against either supported backend
+- **THEN** the command processor SHALL use the same domain model and repository interface
+- **AND** only the event-store infrastructure SHALL vary by backend.
+
+### Requirement: DynamoDB compatibility preservation
+The system SHALL preserve the existing DynamoDB local verification path while adding Spanner support.
+
+#### Scenario: Existing DynamoDB E2E flow
+- **WHEN** the DynamoDB local stack is started
+- **THEN** the existing write API, DynamoDB stream, RMU, MySQL read model, and read API flow SHALL remain verifiable end to end.

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
@@ -13,6 +13,12 @@ The system SHALL allow the write API to select either the DynamoDB event-store b
 - **THEN** it SHALL construct a Spanner event store using the `event-store-adapter-js` 3.0.0 object-input API
 - **AND** it SHALL use caller-managed Spanner database configuration.
 
+#### Scenario: Unsupported backend selected
+- **WHEN** the write API starts with an empty or unknown `PERSISTENCE_BACKEND` value
+- **THEN** startup SHALL fail fast with a clear error message that identifies the invalid value and lists `dynamodb` and `spanner` as supported backends
+- **AND** it SHALL fail before constructing any DynamoDB or Spanner event store through the `event-store-adapter-js` 3.0.0 object-input API
+- **AND** it SHALL NOT fall back implicitly to either supported backend.
+
 ### Requirement: Shared command application
 The system SHALL keep command-domain, command-processor, repository, and GraphQL behavior shared across DynamoDB and Spanner backends.
 

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Spanner production RMU topology
+The system SHALL define the Spanner production read-model update topology as Spanner Change Streams to Dataflow to Pub/Sub to Cloud Run functions or Cloud Functions.
+
+#### Scenario: Journal event is written in production
+- **WHEN** the Spanner event store inserts a domain event into the `journal` table
+- **THEN** the Spanner Change Stream over `journal` SHALL be the source of the downstream event
+- **AND** the downstream path SHALL deliver the event through Pub/Sub to the RMU function.
+
+### Requirement: Spanner local RMU emulation
+The system SHALL provide a local Spanner verification path that preserves the same integration contract as the production topology.
+
+#### Scenario: Journal event is written locally
+- **WHEN** the Spanner backend runs in local Docker Compose
+- **THEN** the flow SHALL pass through Spanner emulator, a local Change Stream bridge or Beam DirectRunner, Pub/Sub emulator, Functions Framework RMU, and MySQL
+- **AND** the read API SHALL observe the projected read model after the asynchronous flow completes.
+
+#### Scenario: Local flow bypasses Pub/Sub
+- **WHEN** a local implementation reads Spanner journal rows and calls the DAO directly
+- **THEN** it SHALL NOT be considered equivalent to the required Spanner local verification path.
+
+### Requirement: Provider-neutral RMU event application
+The RMU SHALL apply decoded domain events through shared projection logic independent of the source provider.
+
+#### Scenario: DynamoDB stream event is received
+- **WHEN** the AWS adapter receives a DynamoDB stream event
+- **THEN** it SHALL decode the stream record into one or more domain events
+- **AND** it SHALL delegate projection to the shared RMU application service.
+
+#### Scenario: Pub/Sub event is received
+- **WHEN** the GCP adapter receives a Pub/Sub-triggered CloudEvent
+- **THEN** it SHALL decode the Pub/Sub message into one or more domain events
+- **AND** it SHALL delegate projection to the shared RMU application service.
+
+### Requirement: Duplicate delivery tolerance
+The Spanner RMU path SHALL tolerate at-least-once delivery from Pub/Sub and function retries.
+
+#### Scenario: Same event is delivered more than once
+- **WHEN** the RMU receives a duplicate event for the same aggregate id and sequence number
+- **THEN** the read-model update SHALL remain consistent
+- **AND** the verification flow SHALL not depend on exactly-once delivery.

--- a/openspec/changes/support-spanner-backend-local-emulation/tasks.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/tasks.md
@@ -1,0 +1,35 @@
+## 1. Validate Platform Assumptions
+
+- [ ] 1.1 Verify `event-store-adapter-js` 3.0.0 API usage for DynamoDB and Spanner.
+- [ ] 1.2 Verify Cloud Spanner emulator can create the event-store tables needed by the adapter.
+- [ ] 1.3 Verify whether Cloud Spanner emulator supports `CREATE CHANGE STREAM` and `READ_<stream>` for the local bridge.
+- [ ] 1.4 Verify Pub/Sub emulator push subscriptions can deliver to a Functions Framework endpoint inside Docker Compose.
+
+## 2. Event Store Backend Selection
+
+- [ ] 2.1 Add runtime configuration for `PERSISTENCE_BACKEND=dynamodb|spanner`.
+- [ ] 2.2 Replace deprecated `EventStoreFactory.ofDynamoDB(...)` calls with `EventStore.ofDynamoDB({ ... })`.
+- [ ] 2.3 Add Spanner client/database construction and `EventStore.ofSpanner({ ... })` wiring.
+- [ ] 2.4 Update repository integration tests to cover both DynamoDB and Spanner event-store construction.
+
+## 3. RMU Refactoring
+
+- [ ] 3.1 Extract provider-neutral event application logic from DynamoDB stream parsing.
+- [ ] 3.2 Keep the AWS Lambda/DynamoDB stream handler as a thin adapter.
+- [ ] 3.3 Add a Pub/Sub/CloudEvent handler for the GCP RMU path using Functions Framework.
+- [ ] 3.4 Add idempotency handling or document existing idempotency guarantees for duplicate event delivery.
+
+## 4. Local Spanner Pipeline
+
+- [ ] 4.1 Add Spanner emulator service and schema setup for `journal`, `snapshot`, and the `journal` change stream.
+- [ ] 4.2 Add Pub/Sub emulator topic and push subscription setup.
+- [ ] 4.3 Add a local Change Stream bridge or Beam DirectRunner process that publishes journal changes to Pub/Sub.
+- [ ] 4.4 Add a Functions Framework RMU service that consumes Pub/Sub push messages and updates MySQL.
+- [ ] 4.5 Add Docker Compose scripts for starting the Spanner backend path.
+
+## 5. Verification And Documentation
+
+- [ ] 5.1 Add a Spanner backend end-to-end verification command equivalent to the DynamoDB `verify-group-chat` flow.
+- [ ] 5.2 Document DynamoDB and Spanner local startup commands.
+- [ ] 5.3 Document the production GCP topology: Spanner Change Streams, Dataflow, Pub/Sub, and Cloud Run functions / Cloud Functions.
+- [ ] 5.4 Document fallback guidance if native Change Streams are unavailable in the emulator.

--- a/openspec/changes/support-spanner-backend-local-emulation/tasks.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/tasks.md
@@ -17,7 +17,7 @@
 - [ ] 3.1 Extract provider-neutral event application logic from DynamoDB stream parsing.
 - [ ] 3.2 Keep the AWS Lambda/DynamoDB stream handler as a thin adapter.
 - [ ] 3.3 Add a Pub/Sub/CloudEvent handler for the GCP RMU path using Functions Framework.
-- [ ] 3.4 Add idempotency handling or document existing idempotency guarantees for duplicate event delivery.
+- [ ] 3.4 Add verifiable duplicate-delivery handling with either explicit idempotent projection logic or an automated verification artifact that proves existing guarantees tolerate duplicate event delivery.
 
 ## 4. Local Spanner Pipeline
 


### PR DESCRIPTION
## Summary

- Add OpenSpec change `support-spanner-backend-local-emulation`
- Propose `event-store-adapter-js@3.0.0` backend selection for DynamoDB and Spanner
- Define Spanner RMU topology as `Spanner Change Streams -> Dataflow -> Pub/Sub -> Cloud Run functions / Cloud Functions`
- Define local verification as `Spanner emulator -> local Change Stream bridge or Beam DirectRunner -> Pub/Sub emulator -> Functions Framework RMU -> MySQL`

## Scope

This PR is change-only. It does not implement runtime code, Docker Compose services, or dependency updates.

## Validation

- `openspec validate support-spanner-backend-local-emulation`
- `openspec status --change support-spanner-backend-local-emulation`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/spec-only additions that propose future DynamoDB/Spanner parity work; no runtime code, dependencies, or infrastructure is changed in this PR.
> 
> **Overview**
> Adds a new OpenSpec change set `support-spanner-backend-local-emulation` that *plans* an `event-store-adapter-js@3.0.0` upgrade to support **runtime selection** between DynamoDB and Spanner backends via `PERSISTENCE_BACKEND`.
> 
> Defines requirements and target architectures for a Spanner-backed RMU pipeline (prod: Change Streams → Dataflow → Pub/Sub → Functions; local: Spanner emulator → local bridge/Beam → Pub/Sub emulator → Functions Framework → MySQL), plus a task checklist to validate emulator assumptions, refactor RMU into provider-specific adapters with shared projection logic, and document/verify end-to-end flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b02fe9f675f7dbb315921569d29eb8f0ea7c055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specifications for runtime backend selection (DynamoDB vs. Cloud Spanner)
  * Documented Cloud Spanner production architecture and local emulation setup
  * Added comprehensive design and implementation task checklist

* **New Features**
  * Support for Cloud Spanner as a selectable persistence backend
  * Local Spanner emulation with Pub/Sub integration for event streaming

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/cqrs-es-example-js/pull/799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->