### PR TITLE
docs: clarify provider adapter boundaries

### DIFF
--- a/openspec/changes/support-spanner-backend-local-emulation/README.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/README.md
@@ -1,3 +1,3 @@
 # support-spanner-backend-local-emulation
 
-Plan event-store-adapter-js 3.0.0 upgrade with DynamoDB and Spanner backend parity, including local emulation for Spanner Change Streams to Pub/Sub to RMU.
+`event-store-adapter-js` 3.0.0 への更新にあわせて、DynamoDB と Spanner の backend parity を実現する計画です。Spanner Change Streams から Pub/Sub、RMU までのローカルエミュレーションも対象にします。

--- a/openspec/changes/support-spanner-backend-local-emulation/design.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/design.md
@@ -67,11 +67,12 @@ Split RMU into:
   - DynamoDB Stream event adapter
   - Pub/Sub/CloudEvent adapter
 - shared event application service:
-  - accepts decoded `GroupChatEvent` values
+  - accepts provider-neutral `ReadModelUpdaterInput` values
   - applies them through `GroupChatDao`
 
 This avoids duplicating projection rules and makes retries/idempotency behavior easier to reason about.
-The adapters should normalize provider payloads into the same internal RMU input shape before invoking the shared service. Lambda and Functions Framework handlers should stay limited to trigger decoding, acknowledgement/error semantics, and dependency composition.
+The target internal RMU input shape is a provider-neutral wrapper, not `DynamoDBStreamEvent`. Name it `ReadModelUpdaterInput` or equivalent. It should carry the decoded `GroupChatEvent` plus metadata required for ordering, idempotency, and diagnostics, such as aggregate id, sequence number, source provider, observed timestamp, and provider position or retry information when available.
+The current `ReadModelUpdater.updateReadModel(DynamoDBStreamEvent)` shape should move behind the DynamoDB adapter. AWS and GCP adapters should normalize provider payloads into `ReadModelUpdaterInput` before invoking the shared service. Lambda and Functions Framework handlers should stay limited to trigger decoding, acknowledgement/error semantics, and dependency composition.
 
 ### Local Verification
 

--- a/openspec/changes/support-spanner-backend-local-emulation/design.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/design.md
@@ -1,88 +1,88 @@
 ## Context
 
-The current application is wired around DynamoDB as the event-store backend. The write API creates an `EventStoreFactory.ofDynamoDB(...)` instance, the RMU consumes DynamoDB stream records, and local end-to-end verification relies on LocalStack Lambda or a local RMU process to update the MySQL read model.
+現在の application は event-store backend として DynamoDB を中心に配線されています。write API は `EventStoreFactory.ofDynamoDB(...)` instance を作成し、RMU は DynamoDB stream records を消費します。local end-to-end verification は、MySQL read model を更新するために LocalStack Lambda または local RMU process に依存しています。
 
-`event-store-adapter-js` 3.0.0 changes the public API to `EventStore.ofDynamoDB(input)` and adds `EventStore.ofSpanner(input)`. Spanner support is only meaningful for this example if it demonstrates the same write-model to read-model flow as the DynamoDB version.
+`event-store-adapter-js` 3.0.0 では public API が `EventStore.ofDynamoDB(input)` に変わり、`EventStore.ofSpanner(input)` が追加されます。この example における Spanner support は、DynamoDB 版と同じ write-model から read-model までの flow を示せる場合にだけ意味があります。
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Keep a single application/package layout and select the event-store backend at runtime.
-- Maintain DynamoDB behavior and local verification.
-- Add a Spanner backend that reaches the MySQL read model through an asynchronous event stream.
-- Make the Spanner local path realistic enough to verify the same integration contract as production.
-- Keep RMU business logic provider-neutral.
-- Isolate AWS/GCP differences in interface adapters and composition wiring, not in domain or application services.
+- application/package layout は 1 つに保ち、event-store backend を runtime に選択します。
+- DynamoDB behavior と local verification を維持します。
+- asynchronous event stream を通じて MySQL read model に到達する Spanner backend を追加します。
+- Spanner local path は、production と同じ integration contract を検証できる程度に現実的なものにします。
+- RMU business logic は provider-neutral に保ちます。
+- AWS/GCP の差分は domain や application services ではなく、interface adapters と composition wiring に隔離します。
 
 **Non-Goals:**
 
-- Do not split the application into backend-specific packages.
-- Do not use a poller as the accepted Spanner architecture if it bypasses the Change Streams/Pub/Sub contract.
-- Do not require managed Dataflow for local development.
-- Do not adopt Spanner Queue for this change; it requires adapter-level queue send support and is not the selected path.
+- application を backend-specific packages に分割しません。
+- Change Streams/Pub/Sub contract を迂回する poller は、Spanner architecture として採用しません。
+- local development で managed Dataflow を必須にしません。
+- この change では Spanner Queue を採用しません。adapter-level の queue send support が必要であり、選択した path ではありません。
 
 ## Decisions
 
 ### Backend Selection
 
-Use a runtime environment variable such as `PERSISTENCE_BACKEND=dynamodb|spanner`.
+`PERSISTENCE_BACKEND=dynamodb|spanner` のような runtime environment variable を使います。
 
-- `dynamodb` constructs `EventStore.ofDynamoDB({ ... })`.
-- `spanner` constructs `EventStore.ofSpanner({ ... })`.
-- Existing domain, command processor, repository contracts, and GraphQL behavior remain shared.
+- `dynamodb` は `EventStore.ofDynamoDB({ ... })` を構築します。
+- `spanner` は `EventStore.ofSpanner({ ... })` を構築します。
+- 既存の domain, command processor, repository contracts, GraphQL behavior は共有したままにします。
 
-This keeps the example focused on backend substitution rather than duplicate application layouts.
-Provider-specific event-store construction belongs at the interface-adapter/composition boundary, so backend selection does not leak into command handlers or domain services.
+これにより、example の焦点を application layout の重複ではなく backend substitution に置けます。
+provider-specific な event-store construction は interface-adapter/composition boundary に置き、backend selection が command handlers や domain services に漏れないようにします。
 
 ### DynamoDB RMU Path
 
-Keep the current AWS-compatible path:
+現在の AWS-compatible path を維持します。
 
 `LocalStack DynamoDB -> DynamoDB Streams -> LocalStack Lambda/localRmu -> MySQL`
 
-The current Lambda-style handler remains useful, but its event decoding should delegate to a shared RMU application service.
+現在の Lambda-style handler は引き続き有用ですが、event decoding 後の処理は shared RMU application service に委譲します。
 
 ### Spanner Production RMU Path
 
-Use the GCP path:
+GCP path は次の構成にします。
 
 `Spanner journal -> Spanner Change Streams -> Dataflow -> Pub/Sub -> Cloud Run functions / Cloud Functions -> MySQL`
 
-The Change Stream must watch `journal`, not `snapshot`, so only domain event inserts drive read-model updates.
+Change Stream は `snapshot` ではなく `journal` を watch します。これにより、domain event inserts だけが read-model updates を駆動します。
 
 ### Spanner Local RMU Path
 
-Use local emulators and a local bridge:
+local emulators と local bridge を使います。
 
 `Spanner emulator -> local Change Stream bridge or Beam DirectRunner -> Pub/Sub emulator -> Functions Framework RMU -> MySQL`
 
-The local bridge is the replacement for managed Dataflow in development. It must preserve the Pub/Sub message contract consumed by the Functions Framework RMU. Pub/Sub emulator push subscriptions can deliver messages to an HTTP endpoint, which is the local equivalent of a Pub/Sub-triggered function.
+local bridge は development における managed Dataflow の代替です。Functions Framework RMU が消費する Pub/Sub message contract を維持しなければなりません。Pub/Sub emulator の push subscriptions は HTTP endpoint に message を配信できるため、これは Pub/Sub-triggered function の local equivalent になります。
 
 ### RMU Core Shape
 
-Split RMU into:
+RMU は次のように分割します。
 
 - provider-specific interface adapters:
   - DynamoDB Stream event adapter
   - Pub/Sub/CloudEvent adapter
 - shared event application service:
-  - accepts provider-neutral `ReadModelUpdaterInput` values
-  - applies them through `GroupChatDao`
+  - provider-neutral な `ReadModelUpdaterInput` values を受け取る
+  - `GroupChatDao` を通じて適用する
 
-This avoids duplicating projection rules and makes retries/idempotency behavior easier to reason about.
-The target internal RMU input shape is a provider-neutral wrapper, not `DynamoDBStreamEvent`. Name it `ReadModelUpdaterInput` or equivalent. It should carry the decoded `GroupChatEvent` plus metadata required for ordering, idempotency, and diagnostics, such as aggregate id, sequence number, source provider, observed timestamp, and provider position or retry information when available.
-The current `ReadModelUpdater.updateReadModel(DynamoDBStreamEvent)` shape should move behind the DynamoDB adapter. AWS and GCP adapters should normalize provider payloads into `ReadModelUpdaterInput` before invoking the shared service. Lambda and Functions Framework handlers should stay limited to trigger decoding, acknowledgement/error semantics, and dependency composition.
+これにより projection rules の重複を避け、retries/idempotency behavior を推論しやすくします。
+target となる internal RMU input shape は `DynamoDBStreamEvent` ではなく provider-neutral wrapper です。名前は `ReadModelUpdaterInput` または同等のものにします。decoded `GroupChatEvent` に加えて、ordering, idempotency, diagnostics に必要な metadata を持たせます。例えば aggregate id, sequence number, source provider, observed timestamp, 利用可能な場合は provider position や retry information です。
+現在の `ReadModelUpdater.updateReadModel(DynamoDBStreamEvent)` shape は DynamoDB adapter の背後に移します。AWS/GCP adapters は shared service を呼び出す前に provider payloads を `ReadModelUpdaterInput` に normalize します。Lambda と Functions Framework handlers は trigger decoding, acknowledgement/error semantics, dependency composition に限定します。
 
 ### Local Verification
 
-Both backend paths must support an end-to-end verification command that creates a group chat through the write API and confirms the read API observes the projected read model.
+両 backend path は、write API で group chat を作成し、read API が projected read model を観測できることを確認する end-to-end verification command を持たなければなりません。
 
-For Spanner, the verification is valid only when the flow crosses the Pub/Sub/function boundary; a direct journal poller calling the DAO is not sufficient.
+Spanner では、flow が Pub/Sub/function boundary を通過した場合にだけ verification として有効です。journal を直接 poll して DAO を呼び出す実装では不十分です。
 
 ## Risks / Trade-offs
 
-- Spanner emulator support for Change Streams must be validated early. If the emulator cannot execute the required `CREATE CHANGE STREAM` and `READ_<stream>` workflow, the local bridge cannot faithfully consume native Change Streams.
-- Managed Dataflow has no LocalStack-style emulator. A local Beam DirectRunner or bridge process is necessary, and it becomes part of the example's development infrastructure.
-- Pub/Sub and function delivery are at-least-once. The RMU must tolerate duplicate deliveries, using event identity such as aggregate id and sequence number where the read model needs idempotency.
-- Dataflow template payloads may not match the ideal RMU payload shape. The bridge/function adapter must define and document the accepted Pub/Sub message schema.
+- Spanner emulator の Change Streams support は早期に検証する必要があります。emulator が必要な `CREATE CHANGE STREAM` と `READ_<stream>` workflow を実行できない場合、local bridge は native Change Streams を忠実に consume できません。
+- Managed Dataflow には LocalStack-style emulator がありません。local Beam DirectRunner または bridge process が必要であり、それは example の development infrastructure の一部になります。
+- Pub/Sub と function delivery は at-least-once です。RMU は duplicate deliveries に耐える必要があります。read model が idempotency を必要とする箇所では、aggregate id や sequence number などの event identity を使います。
+- Dataflow template payloads は理想的な RMU payload shape と一致しない可能性があります。bridge/function adapter は、受け付ける Pub/Sub message schema を定義し文書化する必要があります。

--- a/openspec/changes/support-spanner-backend-local-emulation/design.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/design.md
@@ -13,6 +13,7 @@ The current application is wired around DynamoDB as the event-store backend. The
 - Add a Spanner backend that reaches the MySQL read model through an asynchronous event stream.
 - Make the Spanner local path realistic enough to verify the same integration contract as production.
 - Keep RMU business logic provider-neutral.
+- Isolate AWS/GCP differences in interface adapters and composition wiring, not in domain or application services.
 
 **Non-Goals:**
 
@@ -29,9 +30,10 @@ Use a runtime environment variable such as `PERSISTENCE_BACKEND=dynamodb|spanner
 
 - `dynamodb` constructs `EventStore.ofDynamoDB({ ... })`.
 - `spanner` constructs `EventStore.ofSpanner({ ... })`.
-- Existing domain, command processor, repository, and GraphQL wiring remain shared.
+- Existing domain, command processor, repository contracts, and GraphQL behavior remain shared.
 
 This keeps the example focused on backend substitution rather than duplicate application layouts.
+Provider-specific event-store construction belongs at the interface-adapter/composition boundary, so backend selection does not leak into command handlers or domain services.
 
 ### DynamoDB RMU Path
 
@@ -61,7 +63,7 @@ The local bridge is the replacement for managed Dataflow in development. It must
 
 Split RMU into:
 
-- provider-specific input adapters:
+- provider-specific interface adapters:
   - DynamoDB Stream event adapter
   - Pub/Sub/CloudEvent adapter
 - shared event application service:
@@ -69,6 +71,7 @@ Split RMU into:
   - applies them through `GroupChatDao`
 
 This avoids duplicating projection rules and makes retries/idempotency behavior easier to reason about.
+The adapters should normalize provider payloads into the same internal RMU input shape before invoking the shared service. Lambda and Functions Framework handlers should stay limited to trigger decoding, acknowledgement/error semantics, and dependency composition.
 
 ### Local Verification
 

--- a/openspec/changes/support-spanner-backend-local-emulation/proposal.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/proposal.md
@@ -1,30 +1,30 @@
 ## Why
 
-`event-store-adapter-js` 3.0.0 adds Cloud Spanner support and changes the public construction API. This example project must demonstrate the updated library with both DynamoDB and Spanner while preserving the current CQRS/ES read-model flow, not only write-side persistence.
+`event-store-adapter-js` 3.0.0 では Cloud Spanner 対応が追加され、公開されている構築 API も変更されました。この example project では、write-side persistence だけでなく、現在の CQRS/ES read-model flow を保ったまま DynamoDB と Spanner の両方で更新後のライブラリを示す必要があります。
 
 ## What Changes
 
-- Update the proposed runtime contract from a DynamoDB-only event store to a selectable `dynamodb` or `spanner` persistence backend.
-- Preserve the existing DynamoDB path with LocalStack DynamoDB Streams and the existing RMU behavior.
-- Add a Spanner path whose production architecture is `Spanner Change Streams -> Dataflow -> Pub/Sub -> Cloud Run functions / Cloud Functions -> MySQL read model`.
-- Add a local Spanner emulation path that verifies the same integration contract with `Spanner emulator -> local Change Stream bridge or Beam DirectRunner -> Pub/Sub emulator -> Functions Framework RMU -> MySQL`.
-- Refactor the RMU plan so event-application logic is shared and cloud-provider handlers are thin adapters.
-- Document startup and verification commands for both backends.
+- runtime contract を DynamoDB-only event store から、`dynamodb` または `spanner` を選択できる persistence backend に更新します。
+- LocalStack DynamoDB Streams と既存 RMU behavior を含む DynamoDB path は維持します。
+- Spanner path を追加します。production architecture は `Spanner Change Streams -> Dataflow -> Pub/Sub -> Cloud Run functions / Cloud Functions -> MySQL read model` です。
+- Spanner の local emulation path を追加します。`Spanner emulator -> local Change Stream bridge or Beam DirectRunner -> Pub/Sub emulator -> Functions Framework RMU -> MySQL` により、同じ integration contract を検証します。
+- event-application logic を共有し、cloud-provider handler を薄い adapter にするよう RMU plan をリファクタリングします。
+- 両 backend の起動・検証コマンドを文書化します。
 
 ## Capabilities
 
 ### New Capabilities
 
-- `event-store-backend-selection`: Runtime selection and construction of DynamoDB and Spanner event stores using `event-store-adapter-js` 3.0.0.
-- `spanner-rmu-pipeline`: Spanner read-model update pipeline with production GCP topology and equivalent local emulation.
+- `event-store-backend-selection`: `event-store-adapter-js` 3.0.0 を使い、DynamoDB と Spanner の event store を runtime に選択・構築します。
+- `spanner-rmu-pipeline`: production GCP topology と同等の local emulation を持つ Spanner read-model update pipeline です。
 
 ### Modified Capabilities
 
-- None.
+- なし。
 
 ## Impact
 
-- Affected packages: `packages/bootstrap`, `packages/rmu`, `packages/command/interface-adaptor-impl`, and integration scripts under `tools/`.
-- Affected infrastructure: LocalStack DynamoDB, Cloud Spanner emulator, Pub/Sub emulator, MySQL, Functions Framework, and a local Change Stream bridge or Beam DirectRunner process.
-- Affected documentation: build/test docs, local startup docs, and production architecture notes for the Spanner path.
-- Dependency impact: `event-store-adapter-js` 3.0.0, `@google-cloud/spanner`, Pub/Sub client/runtime dependencies, and Functions Framework dependencies where needed.
+- 影響を受ける packages: `packages/bootstrap`, `packages/rmu`, `packages/command/interface-adaptor-impl`, `tools/` 配下の integration scripts。
+- 影響を受ける infrastructure: LocalStack DynamoDB, Cloud Spanner emulator, Pub/Sub emulator, MySQL, Functions Framework, local Change Stream bridge または Beam DirectRunner process。
+- 影響を受ける documentation: build/test docs, local startup docs, Spanner path の production architecture notes。
+- dependency への影響: `event-store-adapter-js` 3.0.0, `@google-cloud/spanner`, Pub/Sub client/runtime dependencies, 必要に応じた Functions Framework dependencies。

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
@@ -1,36 +1,36 @@
 ## ADDED Requirements
 
 ### Requirement: Runtime backend selection
-The system SHALL allow the write API to select either the DynamoDB event-store backend or the Spanner event-store backend through runtime configuration without changing application packages.
+system SHALL application packages を変更せずに、runtime configuration によって write API が DynamoDB event-store backend または Spanner event-store backend を選択できるようにしなければなりません。
 
 #### Scenario: DynamoDB backend selected
-- **WHEN** the write API starts with the DynamoDB backend selected
-- **THEN** it SHALL construct a DynamoDB event store using the `event-store-adapter-js` 3.0.0 object-input API
-- **AND** it SHALL preserve the existing DynamoDB table and stream configuration contract.
+- **WHEN** write API が DynamoDB backend を選択した状態で起動する
+- **THEN** `event-store-adapter-js` 3.0.0 の object-input API を使って DynamoDB event store を構築 SHALL しなければならない
+- **AND** 既存の DynamoDB table と stream configuration contract を維持 SHALL しなければならない。
 
 #### Scenario: Spanner backend selected
-- **WHEN** the write API starts with the Spanner backend selected
-- **THEN** it SHALL construct a Spanner event store using the `event-store-adapter-js` 3.0.0 object-input API
-- **AND** it SHALL use caller-managed Spanner database configuration.
+- **WHEN** write API が Spanner backend を選択した状態で起動する
+- **THEN** `event-store-adapter-js` 3.0.0 の object-input API を使って Spanner event store を構築 SHALL しなければならない
+- **AND** caller-managed Spanner database configuration を使う SHALL。
 
 #### Scenario: Unsupported backend selected
-- **WHEN** the write API starts with an empty or unknown `PERSISTENCE_BACKEND` value
-- **THEN** startup SHALL fail fast with a clear error message that identifies the invalid value and lists `dynamodb` and `spanner` as supported backends
-- **AND** it SHALL fail before constructing any DynamoDB or Spanner event store through the `event-store-adapter-js` 3.0.0 object-input API
-- **AND** it SHALL NOT fall back implicitly to either supported backend.
+- **WHEN** write API が空または未知の `PERSISTENCE_BACKEND` value で起動する
+- **THEN** startup SHALL invalid value を示し、supported backends として `dynamodb` と `spanner` を列挙する明確な error message で fail fast しなければならない
+- **AND** `event-store-adapter-js` 3.0.0 の object-input API によって DynamoDB または Spanner event store を構築する前に失敗 SHALL しなければならない
+- **AND** supported backend のいずれにも暗黙的に fallback SHALL NOT してはならない。
 
 ### Requirement: Shared command application
-The system SHALL keep command-domain, command-processor, repository, and GraphQL behavior shared across DynamoDB and Spanner backends.
+system SHALL DynamoDB と Spanner backends の間で command-domain, command-processor, repository, GraphQL behavior を共有しなければなりません。
 
 #### Scenario: Same command flow across backends
-- **WHEN** a group chat command is executed against either supported backend
-- **THEN** the command processor SHALL use the same domain model and repository interface
-- **AND** backend-specific event-store construction SHALL be isolated to interface adapters and composition wiring.
-- **AND** backend selection SHALL NOT leak into domain services or command handlers.
+- **WHEN** group chat command がいずれかの supported backend に対して実行される
+- **THEN** command processor SHALL 同じ domain model と repository interface を使わなければならない
+- **AND** backend-specific event-store construction SHALL interface adapters と composition wiring に隔離しなければならない。
+- **AND** backend selection SHALL NOT domain services や command handlers に漏れてはならない。
 
 ### Requirement: DynamoDB compatibility preservation
-The system SHALL preserve the existing DynamoDB local verification path while adding Spanner support.
+system SHALL Spanner support を追加しながら、既存の DynamoDB local verification path を維持しなければなりません。
 
 #### Scenario: Existing DynamoDB E2E flow
-- **WHEN** the DynamoDB local stack is started
-- **THEN** the existing write API, DynamoDB stream, RMU, MySQL read model, and read API flow SHALL remain verifiable end to end.
+- **WHEN** DynamoDB local stack が起動される
+- **THEN** 既存の write API, DynamoDB stream, RMU, MySQL read model, read API flow SHALL end to end で検証可能なままでなければならない。

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/event-store-backend-selection/spec.md
@@ -25,7 +25,8 @@ The system SHALL keep command-domain, command-processor, repository, and GraphQL
 #### Scenario: Same command flow across backends
 - **WHEN** a group chat command is executed against either supported backend
 - **THEN** the command processor SHALL use the same domain model and repository interface
-- **AND** only the event-store infrastructure SHALL vary by backend.
+- **AND** backend-specific event-store construction SHALL be isolated to interface adapters and composition wiring.
+- **AND** backend selection SHALL NOT leak into domain services or command handlers.
 
 ### Requirement: DynamoDB compatibility preservation
 The system SHALL preserve the existing DynamoDB local verification path while adding Spanner support.

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
@@ -26,14 +26,21 @@ The RMU SHALL apply decoded domain events through shared projection logic indepe
 #### Scenario: DynamoDB stream event is received
 - **WHEN** the AWS adapter receives a DynamoDB stream event
 - **THEN** it SHALL decode the stream record into one or more domain events
-- **AND** it SHALL normalize the provider payload into the same internal RMU input shape used by other adapters
+- **AND** it SHALL normalize each provider payload into a provider-neutral `ReadModelUpdaterInput` or equivalent wrapper
+- **AND** the wrapper SHALL include a decoded `GroupChatEvent` plus metadata needed for ordering, idempotency, and diagnostics
 - **AND** it SHALL delegate projection to the shared RMU application service.
 
 #### Scenario: Pub/Sub event is received
 - **WHEN** the GCP adapter receives a Pub/Sub-triggered CloudEvent
 - **THEN** it SHALL decode the Pub/Sub message into one or more domain events
-- **AND** it SHALL normalize the provider payload into the same internal RMU input shape used by other adapters
+- **AND** it SHALL normalize each provider payload into the same provider-neutral `ReadModelUpdaterInput` or equivalent wrapper used by the AWS adapter
+- **AND** the wrapper SHALL include a decoded `GroupChatEvent` plus metadata needed for ordering, idempotency, and diagnostics
 - **AND** it SHALL delegate projection to the shared RMU application service.
+
+#### Scenario: Shared RMU service is invoked
+- **WHEN** provider-specific adapters invoke the shared RMU application service
+- **THEN** the service SHALL accept the provider-neutral wrapper rather than an AWS `DynamoDBStreamEvent` or GCP Pub/Sub payload
+- **AND** provider-native payload types SHALL remain outside the shared projection service.
 
 #### Scenario: Provider handler contains projection logic
 - **WHEN** an AWS Lambda handler or GCP Functions Framework handler receives a provider event

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
@@ -1,56 +1,56 @@
 ## ADDED Requirements
 
 ### Requirement: Spanner production RMU topology
-The system SHALL define the Spanner production read-model update topology as Spanner Change Streams to Dataflow to Pub/Sub to Cloud Run functions or Cloud Functions.
+system SHALL Spanner production read-model update topology を Spanner Change Streams から Dataflow、Pub/Sub、Cloud Run functions または Cloud Functions への flow として定義しなければなりません。
 
 #### Scenario: Journal event is written in production
-- **WHEN** the Spanner event store inserts a domain event into the `journal` table
-- **THEN** the Spanner Change Stream over `journal` SHALL be the source of the downstream event
-- **AND** the downstream path SHALL deliver the event through Pub/Sub to the RMU function.
+- **WHEN** Spanner event store が domain event を `journal` table に insert する
+- **THEN** `journal` に対する Spanner Change Stream SHALL downstream event の source でなければならない
+- **AND** downstream path SHALL Pub/Sub 経由で RMU function に event を deliver しなければならない。
 
 ### Requirement: Spanner local RMU emulation
-The system SHALL provide a local Spanner verification path that preserves the same integration contract as the production topology.
+system SHALL production topology と同じ integration contract を維持する local Spanner verification path を提供しなければなりません。
 
 #### Scenario: Journal event is written locally
-- **WHEN** the Spanner backend runs in local Docker Compose
-- **THEN** the flow SHALL pass through Spanner emulator, a local Change Stream bridge or Beam DirectRunner, Pub/Sub emulator, Functions Framework RMU, and MySQL
-- **AND** the read API SHALL observe the projected read model after the asynchronous flow completes.
+- **WHEN** Spanner backend が local Docker Compose で動作する
+- **THEN** flow SHALL Spanner emulator, local Change Stream bridge または Beam DirectRunner, Pub/Sub emulator, Functions Framework RMU, MySQL を通過しなければならない
+- **AND** asynchronous flow の完了後、read API SHALL projected read model を観測できなければならない。
 
 #### Scenario: Local flow bypasses Pub/Sub
-- **WHEN** a local implementation reads Spanner journal rows and calls the DAO directly
-- **THEN** it SHALL NOT be considered equivalent to the required Spanner local verification path.
+- **WHEN** local implementation が Spanner journal rows を読み、DAO を直接呼び出す
+- **THEN** required Spanner local verification path と同等とはみなす SHALL NOT。
 
 ### Requirement: Provider-neutral RMU event application
-The RMU SHALL apply decoded domain events through shared projection logic independent of the source provider.
+RMU SHALL source provider に依存しない shared projection logic を通じて decoded domain events を apply しなければなりません。
 
 #### Scenario: DynamoDB stream event is received
-- **WHEN** the AWS adapter receives a DynamoDB stream event
-- **THEN** it SHALL decode the stream record into one or more domain events
-- **AND** it SHALL normalize each provider payload into a provider-neutral `ReadModelUpdaterInput` or equivalent wrapper
-- **AND** the wrapper SHALL include a decoded `GroupChatEvent` plus metadata needed for ordering, idempotency, and diagnostics
-- **AND** it SHALL delegate projection to the shared RMU application service.
+- **WHEN** AWS adapter が DynamoDB stream event を受信する
+- **THEN** stream record を 1 つ以上の domain events に decode SHALL しなければならない
+- **AND** 各 provider payload を provider-neutral な `ReadModelUpdaterInput` または同等の wrapper に normalize SHALL しなければならない
+- **AND** wrapper SHALL decoded `GroupChatEvent` に加え、ordering, idempotency, diagnostics に必要な metadata を含まなければならない
+- **AND** projection を shared RMU application service に委譲 SHALL しなければならない。
 
 #### Scenario: Pub/Sub event is received
-- **WHEN** the GCP adapter receives a Pub/Sub-triggered CloudEvent
-- **THEN** it SHALL decode the Pub/Sub message into one or more domain events
-- **AND** it SHALL normalize each provider payload into the same provider-neutral `ReadModelUpdaterInput` or equivalent wrapper used by the AWS adapter
-- **AND** the wrapper SHALL include a decoded `GroupChatEvent` plus metadata needed for ordering, idempotency, and diagnostics
-- **AND** it SHALL delegate projection to the shared RMU application service.
+- **WHEN** GCP adapter が Pub/Sub-triggered CloudEvent を受信する
+- **THEN** Pub/Sub message を 1 つ以上の domain events に decode SHALL しなければならない
+- **AND** 各 provider payload を AWS adapter と同じ provider-neutral な `ReadModelUpdaterInput` または同等の wrapper に normalize SHALL しなければならない
+- **AND** wrapper SHALL decoded `GroupChatEvent` に加え、ordering, idempotency, diagnostics に必要な metadata を含まなければならない
+- **AND** projection を shared RMU application service に委譲 SHALL しなければならない。
 
 #### Scenario: Shared RMU service is invoked
-- **WHEN** provider-specific adapters invoke the shared RMU application service
-- **THEN** the service SHALL accept the provider-neutral wrapper rather than an AWS `DynamoDBStreamEvent` or GCP Pub/Sub payload
-- **AND** provider-native payload types SHALL remain outside the shared projection service.
+- **WHEN** provider-specific adapters が shared RMU application service を呼び出す
+- **THEN** service SHALL AWS `DynamoDBStreamEvent` や GCP Pub/Sub payload ではなく provider-neutral wrapper を受け取らなければならない
+- **AND** provider-native payload types SHALL shared projection service の外側に留めなければならない。
 
 #### Scenario: Provider handler contains projection logic
-- **WHEN** an AWS Lambda handler or GCP Functions Framework handler receives a provider event
-- **THEN** the handler SHALL limit itself to trigger decoding, acknowledgement/error semantics, and dependency composition
-- **AND** it SHALL NOT implement provider-specific projection rules outside the shared RMU application service.
+- **WHEN** AWS Lambda handler または GCP Functions Framework handler が provider event を受信する
+- **THEN** handler SHALL trigger decoding, acknowledgement/error semantics, dependency composition に責務を限定しなければならない
+- **AND** shared RMU application service の外側で provider-specific projection rules を実装 SHALL NOT してはならない。
 
 ### Requirement: Duplicate delivery tolerance
-The Spanner RMU path SHALL tolerate at-least-once delivery from Pub/Sub and function retries.
+Spanner RMU path SHALL Pub/Sub と function retries による at-least-once delivery に耐えなければなりません。
 
 #### Scenario: Same event is delivered more than once
-- **WHEN** the RMU receives a duplicate event for the same aggregate id and sequence number
-- **THEN** the read-model update SHALL remain consistent
-- **AND** the verification flow SHALL not depend on exactly-once delivery.
+- **WHEN** RMU が同じ aggregate id と sequence number の duplicate event を受信する
+- **THEN** read-model update SHALL consistent なままでなければならない
+- **AND** verification flow SHALL NOT exactly-once delivery に依存してはならない。

--- a/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/specs/spanner-rmu-pipeline/spec.md
@@ -26,12 +26,19 @@ The RMU SHALL apply decoded domain events through shared projection logic indepe
 #### Scenario: DynamoDB stream event is received
 - **WHEN** the AWS adapter receives a DynamoDB stream event
 - **THEN** it SHALL decode the stream record into one or more domain events
+- **AND** it SHALL normalize the provider payload into the same internal RMU input shape used by other adapters
 - **AND** it SHALL delegate projection to the shared RMU application service.
 
 #### Scenario: Pub/Sub event is received
 - **WHEN** the GCP adapter receives a Pub/Sub-triggered CloudEvent
 - **THEN** it SHALL decode the Pub/Sub message into one or more domain events
+- **AND** it SHALL normalize the provider payload into the same internal RMU input shape used by other adapters
 - **AND** it SHALL delegate projection to the shared RMU application service.
+
+#### Scenario: Provider handler contains projection logic
+- **WHEN** an AWS Lambda handler or GCP Functions Framework handler receives a provider event
+- **THEN** the handler SHALL limit itself to trigger decoding, acknowledgement/error semantics, and dependency composition
+- **AND** it SHALL NOT implement provider-specific projection rules outside the shared RMU application service.
 
 ### Requirement: Duplicate delivery tolerance
 The Spanner RMU path SHALL tolerate at-least-once delivery from Pub/Sub and function retries.

--- a/openspec/changes/support-spanner-backend-local-emulation/tasks.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/tasks.md
@@ -19,7 +19,9 @@
 - [ ] 3.2 Keep the AWS Lambda/DynamoDB stream handler as a thin adapter.
 - [ ] 3.3 Add a Pub/Sub/CloudEvent handler for the GCP RMU path using Functions Framework.
 - [ ] 3.4 Add verifiable duplicate-delivery handling with either explicit idempotent projection logic or an automated verification artifact that proves existing guarantees tolerate duplicate event delivery.
-- [ ] 3.5 Add shared adapter contract tests or fixtures proving AWS and GCP RMU adapters produce the same internal RMU input shape for equivalent domain events.
+- [ ] 3.5 Define a provider-neutral `ReadModelUpdaterInput` or equivalent wrapper that carries decoded `GroupChatEvent` plus ordering/idempotency/diagnostic metadata.
+- [ ] 3.6 Change the shared RMU application service to accept the provider-neutral wrapper instead of `DynamoDBStreamEvent`.
+- [ ] 3.7 Add shared adapter contract tests or fixtures proving AWS and GCP RMU adapters produce the same wrapper shape for equivalent domain events.
 
 ## 4. Local Spanner Pipeline
 

--- a/openspec/changes/support-spanner-backend-local-emulation/tasks.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/tasks.md
@@ -11,6 +11,7 @@
 - [ ] 2.2 Replace deprecated `EventStoreFactory.ofDynamoDB(...)` calls with `EventStore.ofDynamoDB({ ... })`.
 - [ ] 2.3 Add Spanner client/database construction and `EventStore.ofSpanner({ ... })` wiring.
 - [ ] 2.4 Update repository integration tests to cover both DynamoDB and Spanner event-store construction.
+- [ ] 2.5 Keep backend selection inside interface-adapter/composition wiring so command handlers and domain services remain backend-agnostic.
 
 ## 3. RMU Refactoring
 
@@ -18,6 +19,7 @@
 - [ ] 3.2 Keep the AWS Lambda/DynamoDB stream handler as a thin adapter.
 - [ ] 3.3 Add a Pub/Sub/CloudEvent handler for the GCP RMU path using Functions Framework.
 - [ ] 3.4 Add verifiable duplicate-delivery handling with either explicit idempotent projection logic or an automated verification artifact that proves existing guarantees tolerate duplicate event delivery.
+- [ ] 3.5 Add shared adapter contract tests or fixtures proving AWS and GCP RMU adapters produce the same internal RMU input shape for equivalent domain events.
 
 ## 4. Local Spanner Pipeline
 

--- a/openspec/changes/support-spanner-backend-local-emulation/tasks.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/tasks.md
@@ -1,39 +1,39 @@
-## 1. Validate Platform Assumptions
+## 1. Platform Assumptions の検証
 
-- [ ] 1.1 Verify `event-store-adapter-js` 3.0.0 API usage for DynamoDB and Spanner.
-- [ ] 1.2 Verify Cloud Spanner emulator can create the event-store tables needed by the adapter.
-- [ ] 1.3 Verify whether Cloud Spanner emulator supports `CREATE CHANGE STREAM` and `READ_<stream>` for the local bridge.
-- [ ] 1.4 Verify Pub/Sub emulator push subscriptions can deliver to a Functions Framework endpoint inside Docker Compose.
+- [ ] 1.1 DynamoDB と Spanner での `event-store-adapter-js` 3.0.0 API usage を検証する。
+- [ ] 1.2 Cloud Spanner emulator が adapter に必要な event-store tables を作成できることを検証する。
+- [ ] 1.3 local bridge のために、Cloud Spanner emulator が `CREATE CHANGE STREAM` と `READ_<stream>` を support するか検証する。
+- [ ] 1.4 Pub/Sub emulator の push subscriptions が Docker Compose 内の Functions Framework endpoint に deliver できることを検証する。
 
 ## 2. Event Store Backend Selection
 
-- [ ] 2.1 Add runtime configuration for `PERSISTENCE_BACKEND=dynamodb|spanner`.
-- [ ] 2.2 Replace deprecated `EventStoreFactory.ofDynamoDB(...)` calls with `EventStore.ofDynamoDB({ ... })`.
-- [ ] 2.3 Add Spanner client/database construction and `EventStore.ofSpanner({ ... })` wiring.
-- [ ] 2.4 Update repository integration tests to cover both DynamoDB and Spanner event-store construction.
-- [ ] 2.5 Keep backend selection inside interface-adapter/composition wiring so command handlers and domain services remain backend-agnostic.
+- [ ] 2.1 `PERSISTENCE_BACKEND=dynamodb|spanner` の runtime configuration を追加する。
+- [ ] 2.2 deprecated な `EventStoreFactory.ofDynamoDB(...)` calls を `EventStore.ofDynamoDB({ ... })` に置き換える。
+- [ ] 2.3 Spanner client/database construction と `EventStore.ofSpanner({ ... })` wiring を追加する。
+- [ ] 2.4 repository integration tests を更新し、DynamoDB と Spanner の event-store construction の両方を cover する。
+- [ ] 2.5 backend selection は interface-adapter/composition wiring の内側に保ち、command handlers と domain services を backend-agnostic のままにする。
 
 ## 3. RMU Refactoring
 
-- [ ] 3.1 Extract provider-neutral event application logic from DynamoDB stream parsing.
-- [ ] 3.2 Keep the AWS Lambda/DynamoDB stream handler as a thin adapter.
-- [ ] 3.3 Add a Pub/Sub/CloudEvent handler for the GCP RMU path using Functions Framework.
-- [ ] 3.4 Add verifiable duplicate-delivery handling with either explicit idempotent projection logic or an automated verification artifact that proves existing guarantees tolerate duplicate event delivery.
-- [ ] 3.5 Define a provider-neutral `ReadModelUpdaterInput` or equivalent wrapper that carries decoded `GroupChatEvent` plus ordering/idempotency/diagnostic metadata.
-- [ ] 3.6 Change the shared RMU application service to accept the provider-neutral wrapper instead of `DynamoDBStreamEvent`.
-- [ ] 3.7 Add shared adapter contract tests or fixtures proving AWS and GCP RMU adapters produce the same wrapper shape for equivalent domain events.
+- [ ] 3.1 DynamoDB stream parsing から provider-neutral event application logic を抽出する。
+- [ ] 3.2 AWS Lambda/DynamoDB stream handler は thin adapter として維持する。
+- [ ] 3.3 Functions Framework を使い、GCP RMU path 用の Pub/Sub/CloudEvent handler を追加する。
+- [ ] 3.4 explicit idempotent projection logic、または existing guarantees が duplicate event delivery に耐えることを証明する automated verification artifact により、検証可能な duplicate-delivery handling を追加する。
+- [ ] 3.5 decoded `GroupChatEvent` と ordering/idempotency/diagnostic metadata を持つ provider-neutral な `ReadModelUpdaterInput` または同等の wrapper を定義する。
+- [ ] 3.6 shared RMU application service を変更し、`DynamoDBStreamEvent` ではなく provider-neutral wrapper を受け取るようにする。
+- [ ] 3.7 equivalent domain events に対して AWS/GCP RMU adapters が同じ wrapper shape を生成することを証明する shared adapter contract tests または fixtures を追加する。
 
 ## 4. Local Spanner Pipeline
 
-- [ ] 4.1 Add Spanner emulator service and schema setup for `journal`, `snapshot`, and the `journal` change stream.
-- [ ] 4.2 Add Pub/Sub emulator topic and push subscription setup.
-- [ ] 4.3 Add a local Change Stream bridge or Beam DirectRunner process that publishes journal changes to Pub/Sub.
-- [ ] 4.4 Add a Functions Framework RMU service that consumes Pub/Sub push messages and updates MySQL.
-- [ ] 4.5 Add Docker Compose scripts for starting the Spanner backend path.
+- [ ] 4.1 Spanner emulator service と、`journal`, `snapshot`, `journal` change stream の schema setup を追加する。
+- [ ] 4.2 Pub/Sub emulator topic と push subscription setup を追加する。
+- [ ] 4.3 journal changes を Pub/Sub に publish する local Change Stream bridge または Beam DirectRunner process を追加する。
+- [ ] 4.4 Pub/Sub push messages を consume して MySQL を更新する Functions Framework RMU service を追加する。
+- [ ] 4.5 Spanner backend path を起動する Docker Compose scripts を追加する。
 
 ## 5. Verification And Documentation
 
-- [ ] 5.1 Add a Spanner backend end-to-end verification command equivalent to the DynamoDB `verify-group-chat` flow.
-- [ ] 5.2 Document DynamoDB and Spanner local startup commands.
-- [ ] 5.3 Document the production GCP topology: Spanner Change Streams, Dataflow, Pub/Sub, and Cloud Run functions / Cloud Functions.
-- [ ] 5.4 Document fallback guidance if native Change Streams are unavailable in the emulator.
+- [ ] 5.1 DynamoDB の `verify-group-chat` flow と同等の Spanner backend end-to-end verification command を追加する。
+- [ ] 5.2 DynamoDB と Spanner の local startup commands を文書化する。
+- [ ] 5.3 production GCP topology として、Spanner Change Streams, Dataflow, Pub/Sub, Cloud Run functions / Cloud Functions を文書化する。
+- [ ] 5.4 emulator で native Change Streams が利用できない場合の fallback guidance を文書化する。


### PR DESCRIPTION
## Summary
- clarify that AWS/GCP differences belong in interface adapters and composition wiring, not domain/application services
- require event-store backend selection to stay out of command handlers and domain services
- require AWS and GCP RMU adapters to normalize provider payloads into the same internal RMU input shape
- add adapter contract-test/fixture task for equivalent domain events

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/j5ik2o/.codex/worktrees/fed4/cqrs-es-example-js/mise.toml mise exec -- openspec validate support-spanner-backend-local-emulation
- MISE_TRUSTED_CONFIG_PATHS=/Users/j5ik2o/.codex/worktrees/fed4/cqrs-es-example-js/mise.toml mise exec -- openspec status --change support-spanner-backend-local-emulation
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/spec-only changes that tighten architectural requirements around provider boundaries and RMU normalization; no runtime behavior is modified.
> 
> **Overview**
> Updates the `support-spanner-backend-local-emulation` change docs/specs to **tighten multi-provider architectural constraints** for the upcoming `event-store-adapter-js` 3.0.0 upgrade.
> 
> Clarifies that backend selection (`PERSISTENCE_BACKEND=dynamodb|spanner`) and provider differences must stay in *interface adapters/composition wiring*, and that AWS/GCP RMU handlers should normalize events into a shared provider-neutral `ReadModelUpdaterInput` shape (with ordering/idempotency metadata) before calling shared projection logic.
> 
> Expands requirements/tasks for the Spanner pipeline, explicitly requiring the local verification path to traverse Change Streams/bridge → Pub/Sub emulator → Functions Framework (and disallowing direct journal polling), and adds a task to create adapter contract tests/fixtures proving equivalent cross-provider normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208464aabbf1dfce3df4734d3fc3f807136f9be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design specifications and requirements for Spanner backend local emulation support, clarifying architectural constraints for multi-provider compatibility
  * Expanded event processing specifications with explicit scenarios for AWS and GCP providers, defining adapter behavior and handler responsibilities

* **Tests**
  * Added requirement for shared adapter contract tests ensuring cross-provider compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/cqrs-es-example-js/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->