### PR TITLE
Spanner Pub/Sub 関連の関数名を統一

### DIFF
--- a/docs/spanner-local-pipeline.md
+++ b/docs/spanner-local-pipeline.md
@@ -39,7 +39,7 @@ through an idempotent `GroupChatDao` (so the projection tolerates at-least-once 
 duplicate delivery).
 
 - **AWS** (`decodeDynamoDBStreamEvent`): DynamoDB Streams → `ReadModelUpdaterInput`.
-- **GCP** (`decodePubSubMessage`): Pub/Sub message → `ReadModelUpdaterInput`.
+- **GCP** (`decodeSpannerPubSubMessage`): Pub/Sub message → `ReadModelUpdaterInput`.
 
 The AWS Lambda handler and the GCP Functions Framework handler are thin: they
 only decode the trigger and forward to the shared service.

--- a/openspec/changes/support-spanner-backend-local-emulation/design.md
+++ b/openspec/changes/support-spanner-backend-local-emulation/design.md
@@ -72,7 +72,7 @@ RMU は次のように分割します。
 
 これにより projection rules の重複を避け、retries/idempotency behavior を推論しやすくします。
 target となる internal RMU input shape は `DynamoDBStreamEvent` ではなく provider-neutral wrapper です。名前は `ReadModelUpdaterInput` または同等のものにします。decoded `GroupChatEvent` に加えて、ordering, idempotency, diagnostics に必要な metadata を持たせます。例えば aggregate id, sequence number, source provider, observed timestamp, 利用可能な場合は provider position や retry information です。
-現在の `ReadModelUpdater.updateReadModel(DynamoDBStreamEvent)` shape は DynamoDB adapter の背後に移します。AWS/GCP adapters は shared service を呼び出す前に provider payloads を `ReadModelUpdaterInput` に normalize します。Lambda と Functions Framework handlers は trigger decoding, acknowledgement/error semantics, dependency composition に限定します。
+`ReadModelUpdater.updateFromDynamoDBStream(DynamoDBStreamEvent)` と `ReadModelUpdater.updateFromSpannerPubSub(SpannerPubSubMessage)` は provider-specific adapters の入口に限定します。AWS/GCP adapters は shared service を呼び出す前に provider payloads を `ReadModelUpdaterInput` に normalize します。Lambda と Functions Framework handlers は trigger decoding, acknowledgement/error semantics, dependency composition に限定します。
 
 ### Local Verification
 

--- a/packages/bootstrap/src/dynamodb-lambda-rmu-handler.ts
+++ b/packages/bootstrap/src/dynamodb-lambda-rmu-handler.ts
@@ -24,6 +24,8 @@ function getReadModelUpdater(): ReadModelUpdater {
   return readModelUpdater;
 }
 
-export const handler: Handler<DynamoDBStreamEvent, void> = async (event) => {
-  await getReadModelUpdater().updateReadModel(event);
+export const handler: Handler<DynamoDBStreamEvent, void> = async (
+  dynamodbStreamEvent,
+) => {
+  await getReadModelUpdater().updateFromDynamoDBStream(dynamodbStreamEvent);
 };

--- a/packages/bootstrap/src/dynamodb-local-rmu-main.ts
+++ b/packages/bootstrap/src/dynamodb-local-rmu-main.ts
@@ -176,7 +176,7 @@ async function streamDriver(
           const item = getItem(record);
           logger.info(`keys = ${JSON.stringify(keys)}`);
           logger.info(`item = ${JSON.stringify(item)}`);
-          await readModelUpdater.updateReadModel(
+          await readModelUpdater.updateFromDynamoDBStream(
             convertToEvent(record, keys, item, streamArn),
           );
         }

--- a/packages/bootstrap/src/spanner-rmu-handler.ts
+++ b/packages/bootstrap/src/spanner-rmu-handler.ts
@@ -40,25 +40,30 @@ function getReadModelUpdater(): ReadModelUpdater {
 
 cloudEvent<SpannerPubSubCloudEventData>(
   "readModelUpdater",
-  async (event: CloudEvent<SpannerPubSubCloudEventData>) => {
+  async (spannerPubSubCloudEvent: CloudEvent<SpannerPubSubCloudEventData>) => {
     // Throw on a malformed payload rather than returning: a thrown error makes
     // the Functions Framework respond non-2xx so Pub/Sub retries / dead-letters
     // the message instead of silently acking and dropping it.
-    const message = extractSpannerPubSubMessage(event);
-    await getReadModelUpdater().updateFromSpannerPubSub(message);
+    const spannerPubSubMessage = extractSpannerPubSubMessage(
+      spannerPubSubCloudEvent,
+    );
+    await getReadModelUpdater().updateFromSpannerPubSub(spannerPubSubMessage);
   },
 );
 
 function extractSpannerPubSubMessage(
-  event: CloudEvent<SpannerPubSubCloudEventData>,
+  spannerPubSubCloudEvent: CloudEvent<SpannerPubSubCloudEventData>,
 ): SpannerPubSubMessage {
-  const message = event.data?.message;
-  if (message === undefined || typeof message.data !== "string") {
+  const spannerPubSubMessage = spannerPubSubCloudEvent.data?.message;
+  if (
+    spannerPubSubMessage === undefined ||
+    typeof spannerPubSubMessage.data !== "string"
+  ) {
     throw new Error(
       "Invalid Pub/Sub CloudEvent: missing message.data string payload",
     );
   }
-  return message;
+  return spannerPubSubMessage;
 }
 
 export { getReadModelUpdater };

--- a/packages/bootstrap/src/spanner-rmu-handler.ts
+++ b/packages/bootstrap/src/spanner-rmu-handler.ts
@@ -2,8 +2,8 @@ import { type CloudEvent, cloudEvent } from "@google-cloud/functions-framework";
 import { PrismaClient } from "@prisma/client";
 import {
   GroupChatDao,
-  type PubSubMessage,
   ReadModelUpdater,
+  type SpannerPubSubMessage,
 } from "cqrs-es-example-js-rmu";
 
 /**
@@ -16,8 +16,8 @@ import {
  *   functions-framework --target=readModelUpdater --signature-type=cloudevent
  */
 
-type PubSubCloudEventData = {
-  message: PubSubMessage;
+type SpannerPubSubCloudEventData = {
+  message: SpannerPubSubMessage;
   subscription?: string;
 };
 
@@ -38,20 +38,20 @@ function getReadModelUpdater(): ReadModelUpdater {
   return readModelUpdater;
 }
 
-cloudEvent<PubSubCloudEventData>(
+cloudEvent<SpannerPubSubCloudEventData>(
   "readModelUpdater",
-  async (event: CloudEvent<PubSubCloudEventData>) => {
+  async (event: CloudEvent<SpannerPubSubCloudEventData>) => {
     // Throw on a malformed payload rather than returning: a thrown error makes
     // the Functions Framework respond non-2xx so Pub/Sub retries / dead-letters
     // the message instead of silently acking and dropping it.
-    const message = extractPubSubMessage(event);
-    await getReadModelUpdater().updateFromPubSub(message);
+    const message = extractSpannerPubSubMessage(event);
+    await getReadModelUpdater().updateFromSpannerPubSub(message);
   },
 );
 
-function extractPubSubMessage(
-  event: CloudEvent<PubSubCloudEventData>,
-): PubSubMessage {
+function extractSpannerPubSubMessage(
+  event: CloudEvent<SpannerPubSubCloudEventData>,
+): SpannerPubSubMessage {
   const message = event.data?.message;
   if (message === undefined || typeof message.data !== "string") {
     throw new Error(

--- a/packages/rmu/src/adapter-contract.test.ts
+++ b/packages/rmu/src/adapter-contract.test.ts
@@ -7,7 +7,7 @@ import {
   UserAccountId,
 } from "cqrs-es-example-js-command-domain";
 import { decodeDynamoDBStreamEvent } from "./dynamodb-adapter";
-import { decodePubSubMessage } from "./spanner-pubsub-adapter";
+import { decodeSpannerPubSubMessage } from "./spanner-pubsub-adapter";
 
 // The event-store serializer envelope: JSON.stringify({ type, data }).
 function wirePayload(event: GroupChatEvent): string {
@@ -32,7 +32,7 @@ function asDynamoDBStreamEvent(event: GroupChatEvent): DynamoDBStreamEvent {
   } as unknown as DynamoDBStreamEvent;
 }
 
-function asPubSubMessage(event: GroupChatEvent) {
+function asSpannerPubSubMessage(event: GroupChatEvent) {
   return {
     data: Buffer.from(wirePayload(event), "utf-8").toString("base64"),
     attributes: {
@@ -45,7 +45,7 @@ function asPubSubMessage(event: GroupChatEvent) {
 }
 
 describe("RMU adapter contract", () => {
-  test("DynamoDB and Pub/Sub adapters produce an equivalent wrapper", () => {
+  test("DynamoDB and Spanner Pub/Sub adapters produce an equivalent wrapper", () => {
     const id = GroupChatId.generate();
     const adminId = UserAccountId.generate();
     const [, created] = GroupChat.create(id, GroupChatName.of("name"), adminId);
@@ -53,25 +53,27 @@ describe("RMU adapter contract", () => {
     const [fromDynamo] = decodeDynamoDBStreamEvent(
       asDynamoDBStreamEvent(created),
     );
-    const [fromPubSub] = decodePubSubMessage(asPubSubMessage(created));
+    const [fromSpannerPubSub] = decodeSpannerPubSubMessage(
+      asSpannerPubSubMessage(created),
+    );
 
     // Same decoded domain event identity across providers.
-    expect(fromDynamo.event.typeName).toEqual(fromPubSub.event.typeName);
-    expect(fromDynamo.aggregateId).toEqual(fromPubSub.aggregateId);
-    expect(fromDynamo.sequenceNumber).toEqual(fromPubSub.sequenceNumber);
+    expect(fromDynamo.event.typeName).toEqual(fromSpannerPubSub.event.typeName);
+    expect(fromDynamo.aggregateId).toEqual(fromSpannerPubSub.aggregateId);
+    expect(fromDynamo.sequenceNumber).toEqual(fromSpannerPubSub.sequenceNumber);
     expect(fromDynamo.aggregateId).toEqual(id.asString());
     expect(fromDynamo.sequenceNumber).toEqual(1);
 
     // Provider is tracked distinctly for diagnostics.
     expect(fromDynamo.sourceProvider).toEqual("dynamodb");
-    expect(fromPubSub.sourceProvider).toEqual("spanner");
+    expect(fromSpannerPubSub.sourceProvider).toEqual("spanner");
 
     // Both carry a position for ordering/idempotency.
     expect(fromDynamo.position).toBeDefined();
-    expect(fromPubSub.position).toBeDefined();
+    expect(fromSpannerPubSub.position).toBeDefined();
   });
 
-  test("Pub/Sub adapter reconstructs the full created event payload", () => {
+  test("Spanner Pub/Sub adapter reconstructs the full created event payload", () => {
     const id = GroupChatId.generate();
     const adminId = UserAccountId.generate();
     const [, created] = GroupChat.create(
@@ -80,7 +82,7 @@ describe("RMU adapter contract", () => {
       adminId,
     );
 
-    const [input] = decodePubSubMessage(asPubSubMessage(created));
+    const [input] = decodeSpannerPubSubMessage(asSpannerPubSubMessage(created));
     if (input.event.typeName !== "GroupChatCreated") {
       throw new Error("expected GroupChatCreated");
     }

--- a/packages/rmu/src/adapter-contract.test.ts
+++ b/packages/rmu/src/adapter-contract.test.ts
@@ -50,7 +50,7 @@ describe("RMU adapter contract", () => {
     const adminId = UserAccountId.generate();
     const [, created] = GroupChat.create(id, GroupChatName.of("name"), adminId);
 
-    const [fromDynamo] = decodeDynamoDBStreamEvent(
+    const [fromDynamoDBStream] = decodeDynamoDBStreamEvent(
       asDynamoDBStreamEvent(created),
     );
     const [fromSpannerPubSub] = decodeSpannerPubSubMessage(
@@ -58,18 +58,24 @@ describe("RMU adapter contract", () => {
     );
 
     // Same decoded domain event identity across providers.
-    expect(fromDynamo.event.typeName).toEqual(fromSpannerPubSub.event.typeName);
-    expect(fromDynamo.aggregateId).toEqual(fromSpannerPubSub.aggregateId);
-    expect(fromDynamo.sequenceNumber).toEqual(fromSpannerPubSub.sequenceNumber);
-    expect(fromDynamo.aggregateId).toEqual(id.asString());
-    expect(fromDynamo.sequenceNumber).toEqual(1);
+    expect(fromDynamoDBStream.event.typeName).toEqual(
+      fromSpannerPubSub.event.typeName,
+    );
+    expect(fromDynamoDBStream.aggregateId).toEqual(
+      fromSpannerPubSub.aggregateId,
+    );
+    expect(fromDynamoDBStream.sequenceNumber).toEqual(
+      fromSpannerPubSub.sequenceNumber,
+    );
+    expect(fromDynamoDBStream.aggregateId).toEqual(id.asString());
+    expect(fromDynamoDBStream.sequenceNumber).toEqual(1);
 
     // Provider is tracked distinctly for diagnostics.
-    expect(fromDynamo.sourceProvider).toEqual("dynamodb");
+    expect(fromDynamoDBStream.sourceProvider).toEqual("dynamodb");
     expect(fromSpannerPubSub.sourceProvider).toEqual("spanner");
 
     // Both carry a position for ordering/idempotency.
-    expect(fromDynamo.position).toBeDefined();
+    expect(fromDynamoDBStream.position).toBeDefined();
     expect(fromSpannerPubSub.position).toBeDefined();
   });
 
@@ -94,7 +100,7 @@ describe("RMU adapter contract", () => {
   });
 
   test("DynamoDB adapter rejects INSERT records without a journal payload", () => {
-    const event = {
+    const dynamodbStreamEvent = {
       Records: [
         {
           eventName: "INSERT",
@@ -106,7 +112,7 @@ describe("RMU adapter contract", () => {
       ],
     } as unknown as DynamoDBStreamEvent;
 
-    expect(() => decodeDynamoDBStreamEvent(event)).toThrow(
+    expect(() => decodeDynamoDBStreamEvent(dynamodbStreamEvent)).toThrow(
       "DynamoDB INSERT record is missing NewImage.payload.B",
     );
   });

--- a/packages/rmu/src/dynamodb-adapter.ts
+++ b/packages/rmu/src/dynamodb-adapter.ts
@@ -10,29 +10,29 @@ const decoder = new TextDecoder("utf-8");
  * more provider-neutral `ReadModelUpdaterInput` values.
  */
 function decodeDynamoDBStreamEvent(
-  event: DynamoDBStreamEvent,
+  dynamodbStreamEvent: DynamoDBStreamEvent,
 ): ReadModelUpdaterInput[] {
   const inputs: ReadModelUpdaterInput[] = [];
-  for (const record of event.Records) {
+  for (const dynamodbStreamRecord of dynamodbStreamEvent.Records) {
     // The journal is append-only; only INSERTs carry new domain events. Ignore
     // MODIFY/REMOVE so an item change is never replayed as a fresh event.
-    if (record.eventName !== "INSERT") {
+    if (dynamodbStreamRecord.eventName !== "INSERT") {
       continue;
     }
-    const image = record.dynamodb?.NewImage;
-    const rawPayload = image?.payload?.B;
+    const dynamodbStreamImage = dynamodbStreamRecord.dynamodb?.NewImage;
+    const rawPayload = dynamodbStreamImage?.payload?.B;
     if (rawPayload === undefined) {
       throw new Error(
         `DynamoDB INSERT record is missing NewImage.payload.B (sequenceNumber=${String(
-          record.dynamodb?.SequenceNumber ?? "",
+          dynamodbStreamRecord.dynamodb?.SequenceNumber ?? "",
         )})`,
       );
     }
     const groupChatEvent = convertJSONToGroupChatEvent(
-      parsePayload(rawPayload),
+      parseDynamoDBStreamPayload(rawPayload),
     );
-    const observedAt = approximateCreationToDate(
-      record.dynamodb?.ApproximateCreationDateTime,
+    const observedAt = parseDynamoDBApproximateCreationDate(
+      dynamodbStreamRecord.dynamodb?.ApproximateCreationDateTime,
     );
     inputs.push({
       event: groupChatEvent,
@@ -40,7 +40,7 @@ function decodeDynamoDBStreamEvent(
       sequenceNumber: groupChatEvent.sequenceNumber,
       sourceProvider: "dynamodb",
       observedAt,
-      position: record.dynamodb?.SequenceNumber,
+      position: dynamodbStreamRecord.dynamodb?.SequenceNumber,
     });
   }
   return inputs;
@@ -51,7 +51,7 @@ function decodeDynamoDBStreamEvent(
  * LocalStack and the dynamodb-local-rmu stream driver deliver epoch **milliseconds**.
  * Disambiguate by magnitude so the value never overflows into a garbage date.
  */
-function approximateCreationToDate(value: number | undefined): Date {
+function parseDynamoDBApproximateCreationDate(value: number | undefined): Date {
   if (value === undefined) {
     return new Date();
   }
@@ -61,7 +61,7 @@ function approximateCreationToDate(value: number | undefined): Date {
   return Number.isNaN(date.getTime()) ? new Date() : date;
 }
 
-function parsePayload(rawPayload: string): unknown {
+function parseDynamoDBStreamPayload(rawPayload: string): unknown {
   try {
     // LocalStack: the B field carries a raw JSON string.
     return JSON.parse(rawPayload);

--- a/packages/rmu/src/read-model-updater.integration.test.ts
+++ b/packages/rmu/src/read-model-updater.integration.test.ts
@@ -37,7 +37,7 @@ function encodePayload(json: string, encoding: PayloadEncoding): string {
   return json;
 }
 
-function streamEventOf(
+function asDynamoDBStreamEvent(
   event: GroupChatEvent,
   encoding: PayloadEncoding = "raw",
 ): DynamoDBStreamEvent {
@@ -114,13 +114,15 @@ describe("ReadModelUpdater (DynamoDB stream -> MySQL)", () => {
         GroupChatName.of("name"),
         adminId,
       );
-      await updater.updateReadModel(streamEventOf(created));
+      await updater.updateFromDynamoDBStream(asDynamoDBStreamEvent(created));
 
       const memberId = UserAccountId.generate();
       const [gc1, memberAdded] = unwrap(
         gc0.addMember(memberId, "member", adminId),
       );
-      await updater.updateReadModel(streamEventOf(memberAdded));
+      await updater.updateFromDynamoDBStream(
+        asDynamoDBStreamEvent(memberAdded),
+      );
 
       const groupChat = await prisma.groupChats.findUnique({
         where: { id: id.asString() },
@@ -140,8 +142,10 @@ describe("ReadModelUpdater (DynamoDB stream -> MySQL)", () => {
       expect(members.length).toEqual(2);
 
       // Idempotency: replaying the same event must not error or duplicate.
-      await updater.updateReadModel(streamEventOf(created));
-      await updater.updateReadModel(streamEventOf(memberAdded));
+      await updater.updateFromDynamoDBStream(asDynamoDBStreamEvent(created));
+      await updater.updateFromDynamoDBStream(
+        asDynamoDBStreamEvent(memberAdded),
+      );
       const membersAfter = await prisma.members.findMany({
         where: { groupChatId: id.asString() },
       });
@@ -171,7 +175,9 @@ describe("ReadModelUpdater (DynamoDB stream -> MySQL)", () => {
           GroupChatName.of(`gc-${encoding}`),
           adminId,
         );
-        await updater.updateReadModel(streamEventOf(created, encoding));
+        await updater.updateFromDynamoDBStream(
+          asDynamoDBStreamEvent(created, encoding),
+        );
         const row = await prisma.groupChats.findUnique({
           where: { id: id.asString() },
         });
@@ -204,12 +210,14 @@ describe("ReadModelUpdater (DynamoDB stream -> MySQL)", () => {
         gc1.rename(GroupChatName.of("after"), adminId),
       );
 
-      await updater.updateReadModel(streamEventOf(created));
+      await updater.updateFromDynamoDBStream(asDynamoDBStreamEvent(created));
       await expect(
-        updater.updateReadModel(streamEventOf(renamed)),
+        updater.updateFromDynamoDBStream(asDynamoDBStreamEvent(renamed)),
       ).rejects.toThrow("Read model projection gap");
-      await updater.updateReadModel(streamEventOf(memberAdded));
-      await updater.updateReadModel(streamEventOf(renamed));
+      await updater.updateFromDynamoDBStream(
+        asDynamoDBStreamEvent(memberAdded),
+      );
+      await updater.updateFromDynamoDBStream(asDynamoDBStreamEvent(renamed));
 
       const groupChat = await prisma.groupChats.findUnique({
         where: { id: id.asString() },

--- a/packages/rmu/src/spanner-pubsub-adapter.ts
+++ b/packages/rmu/src/spanner-pubsub-adapter.ts
@@ -6,7 +6,7 @@ import type { ReadModelUpdaterInput } from "./read-model-updater-input";
  * payload produced by the Spanner change-stream bridge: the same
  * `{ type, data }` event envelope the event store serializes.
  */
-export type PubSubMessage = {
+export type SpannerPubSubMessage = {
   data: string;
   attributes?: Record<string, string>;
   messageId?: string;
@@ -18,7 +18,9 @@ export type PubSubMessage = {
  * `ReadModelUpdaterInput`. Returns an array for symmetry with the DynamoDB
  * adapter.
  */
-function decodePubSubMessage(message: PubSubMessage): ReadModelUpdaterInput[] {
+function decodeSpannerPubSubMessage(
+  message: SpannerPubSubMessage,
+): ReadModelUpdaterInput[] {
   const json = JSON.parse(
     Buffer.from(message.data, "base64").toString("utf-8"),
   );
@@ -50,4 +52,4 @@ function parseObservedAt(value: string | undefined): Date {
   return parsed;
 }
 
-export { decodePubSubMessage };
+export { decodeSpannerPubSubMessage };

--- a/packages/rmu/src/spanner-pubsub-adapter.ts
+++ b/packages/rmu/src/spanner-pubsub-adapter.ts
@@ -19,29 +19,31 @@ export type SpannerPubSubMessage = {
  * adapter.
  */
 function decodeSpannerPubSubMessage(
-  message: SpannerPubSubMessage,
+  spannerPubSubMessage: SpannerPubSubMessage,
 ): ReadModelUpdaterInput[] {
-  const json = JSON.parse(
-    Buffer.from(message.data, "base64").toString("utf-8"),
+  const spannerPubSubPayload = JSON.parse(
+    Buffer.from(spannerPubSubMessage.data, "base64").toString("utf-8"),
   );
-  const event = convertJSONToGroupChatEvent(json);
-  const attributes = message.attributes ?? {};
-  const observedAt = parseObservedAt(
-    attributes.commitTimestamp ?? message.publishTime,
+  const groupChatEvent = convertJSONToGroupChatEvent(spannerPubSubPayload);
+  const spannerPubSubAttributes = spannerPubSubMessage.attributes ?? {};
+  const observedAt = parseSpannerPubSubObservedAt(
+    spannerPubSubAttributes.commitTimestamp ?? spannerPubSubMessage.publishTime,
   );
   return [
     {
-      event,
-      aggregateId: event.aggregateId.asString(),
-      sequenceNumber: event.sequenceNumber,
+      event: groupChatEvent,
+      aggregateId: groupChatEvent.aggregateId.asString(),
+      sequenceNumber: groupChatEvent.sequenceNumber,
       sourceProvider: "spanner",
       observedAt,
-      position: attributes.commitTimestamp ?? message.messageId,
+      position:
+        spannerPubSubAttributes.commitTimestamp ??
+        spannerPubSubMessage.messageId,
     },
   ];
 }
 
-function parseObservedAt(value: string | undefined): Date {
+function parseSpannerPubSubObservedAt(value: string | undefined): Date {
   if (value === undefined) {
     throw new Error("Invalid observedAt timestamp: missing value");
   }

--- a/packages/rmu/src/update-read-model.ts
+++ b/packages/rmu/src/update-read-model.ts
@@ -4,8 +4,8 @@ import { decodeDynamoDBStreamEvent } from "./dynamodb-adapter";
 import type { GroupChatDao } from "./group-chat-dao";
 import type { ReadModelUpdaterInput } from "./read-model-updater-input";
 import {
-  type PubSubMessage,
-  decodePubSubMessage,
+  type SpannerPubSubMessage,
+  decodeSpannerPubSubMessage,
 } from "./spanner-pubsub-adapter";
 
 /**
@@ -17,8 +17,8 @@ import {
 export type ReadModelUpdater = {
   /** AWS / DynamoDB Streams path (kept for the existing local + Lambda RMU). */
   updateReadModel(event: DynamoDBStreamEvent): Promise<void>;
-  /** GCP / Pub/Sub path. */
-  updateFromPubSub(message: PubSubMessage): Promise<void>;
+  /** Spanner Change Streams / Pub/Sub path. */
+  updateFromSpannerPubSub(message: SpannerPubSubMessage): Promise<void>;
   /** Provider-neutral path. */
   apply(inputs: readonly ReadModelUpdaterInput[]): Promise<void>;
 };
@@ -37,8 +37,8 @@ export namespace ReadModelUpdater {
       updateReadModel(event: DynamoDBStreamEvent): Promise<void> {
         return apply(decodeDynamoDBStreamEvent(event));
       },
-      updateFromPubSub(message: PubSubMessage): Promise<void> {
-        return apply(decodePubSubMessage(message));
+      updateFromSpannerPubSub(message: SpannerPubSubMessage): Promise<void> {
+        return apply(decodeSpannerPubSubMessage(message));
       },
     });
   }

--- a/packages/rmu/src/update-read-model.ts
+++ b/packages/rmu/src/update-read-model.ts
@@ -16,9 +16,13 @@ import {
  */
 export type ReadModelUpdater = {
   /** AWS / DynamoDB Streams path (kept for the existing local + Lambda RMU). */
-  updateReadModel(event: DynamoDBStreamEvent): Promise<void>;
+  updateFromDynamoDBStream(
+    dynamodbStreamEvent: DynamoDBStreamEvent,
+  ): Promise<void>;
   /** Spanner Change Streams / Pub/Sub path. */
-  updateFromSpannerPubSub(message: SpannerPubSubMessage): Promise<void>;
+  updateFromSpannerPubSub(
+    spannerPubSubMessage: SpannerPubSubMessage,
+  ): Promise<void>;
   /** Provider-neutral path. */
   apply(inputs: readonly ReadModelUpdaterInput[]): Promise<void>;
 };
@@ -34,11 +38,15 @@ export namespace ReadModelUpdater {
     }
     return Object.freeze({
       apply,
-      updateReadModel(event: DynamoDBStreamEvent): Promise<void> {
-        return apply(decodeDynamoDBStreamEvent(event));
+      updateFromDynamoDBStream(
+        dynamodbStreamEvent: DynamoDBStreamEvent,
+      ): Promise<void> {
+        return apply(decodeDynamoDBStreamEvent(dynamodbStreamEvent));
       },
-      updateFromSpannerPubSub(message: SpannerPubSubMessage): Promise<void> {
-        return apply(decodeSpannerPubSubMessage(message));
+      updateFromSpannerPubSub(
+        spannerPubSubMessage: SpannerPubSubMessage,
+      ): Promise<void> {
+        return apply(decodeSpannerPubSubMessage(spannerPubSubMessage));
       },
     });
   }


### PR DESCRIPTION
## 概要
- `spanner-pubsub-adapter.ts` の型・decoder を `SpannerPubSubMessage` / `decodeSpannerPubSubMessage` に変更しました。
- Spanner RMU handler と shared `ReadModelUpdater` のメソッド名を `updateFromSpannerPubSub` へ揃えました。
- adapter contract test と Spanner pipeline docs の参照名も更新しました。

## 背景
前回 PR でファイル名は `spanner-*` / `dynamodb-*` に揃えましたが、Spanner Pub/Sub 経路の関数・型名に `PubSubMessage` や `decodePubSubMessage` のような汎用名が残っていました。DynamoDB 側の `decodeDynamoDBStreamEvent` と同じ粒度で backend 名が分かるように揃えています。

## 確認
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm build`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm lint`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter cqrs-es-example-js-rmu test -- adapter-contract.test.ts`
- `git diff --check`
- 旧名検索: `PubSubMessage`, `decodePubSubMessage`, `extractPubSubMessage`, `updateFromPubSub`, `asPubSubMessage`, `localRmu` の取り残しなし

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor across handlers, adapters, tests, and docs; projection logic and payloads are unchanged.
> 
> **Overview**
> Renames the read-model update (RMU) **provider entry points** so Spanner and DynamoDB naming match the same pattern (`decodeDynamoDBStreamEvent` ↔ `decodeSpannerPubSubMessage`).
> 
> **Spanner path:** generic `PubSubMessage` / `decodePubSubMessage` / `updateFromPubSub` become **`SpannerPubSubMessage`**, **`decodeSpannerPubSubMessage`**, and **`ReadModelUpdater.updateFromSpannerPubSub`**. The Functions Framework handler and CloudEvent helpers use the Spanner-specific names (`extractSpannerPubSubMessage`, etc.).
> 
> **DynamoDB path:** the shared updater drops **`updateReadModel`** in favor of **`updateFromDynamoDBStream`**, wired from the Lambda handler and local stream driver. Integration and contract tests, plus **`docs/spanner-local-pipeline.md`** and the OpenSpec design note, are updated to the new API names. Adapter behavior is unchanged; this is a **naming-only** alignment after the earlier `spanner-*` / `dynamodb-*` file split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ade7481713fb01b6ed91a251f0bd81ad08f19ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Cloud Spanner as a data source for read-model updates via Pub/Sub Change Streams integration.

* **Documentation**
  * Updated RMU (read-model update) documentation to reflect Spanner-specific message handling.

* **Tests**
  * Updated adapter contract tests to validate Spanner Pub/Sub integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->