### PR TITLE
[codex] shared workflow wrapper を最新 j5ik2o/ci SHA で追加

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -1,0 +1,47 @@
+name: Review Thread Resolution
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to refresh. Leave empty to refresh all open main PRs.
+        required: false
+        type: string
+      wait_for_other_checks:
+        description: Wait for other PR checks before evaluating review threads.
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  checks: write
+  issues: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  refresh:
+    name: Refresh review-thread state
+    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
+    permissions:
+      contents: read
+      checks: write
+      issues: read
+      pull-requests: read
+      statuses: write
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      wait_for_other_checks: ${{ inputs.wait_for_other_checks || 'true' }}
+      ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a

--- a/.github/workflows/takt-review.yml
+++ b/.github/workflows/takt-review.yml
@@ -1,0 +1,37 @@
+name: TAKT Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  takt-review:
+    name: TAKT Review
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '@takt') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    uses: j5ik2o/ci/.github/workflows/takt-review.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      workflow: review-takt-default
+      provider: claude-sdk
+      model: claude-sonnet-4-5-20250929
+      non_blocking: "true"
+      ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a

--- a/.github/workflows/takt-review.yml
+++ b/.github/workflows/takt-review.yml
@@ -15,12 +15,15 @@ jobs:
   takt-review:
     name: TAKT Review
     if: >
-      github.event_name == 'pull_request' ||
+      vars.TAKT_REVIEW_ENABLED == 'true' &&
       (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request != null &&
-        startsWith(github.event.comment.body, '@takt') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          startsWith(github.event.comment.body, '@takt') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
       )
     uses: j5ik2o/ci/.github/workflows/takt-review.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
     permissions:


### PR DESCRIPTION
## 概要

- Review Thread Resolution の shared workflow wrapper を追加
- TAKT Review の shared workflow wrapper を追加
- reusable workflow の ref と ci_ref を j5ik2o/ci の最新 main SHA 560170b61c74a9a643a483a052ccbad0d6ad409a に固定
- ANTHROPIC_API_KEY 未設定の repo で PR チェックを落とさないよう、TAKT Review は TAKT_REVIEW_ENABLED=true の repo variable がある場合のみ実行

## 確認

- yq '.' .github/workflows/review-thread-resolution.yml
- yq '.' .github/workflows/takt-review.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-thread-resolution.yml .github/workflows/takt-review.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only additions with no application runtime changes; TAKT is gated by a repo variable and uses an existing secret for optional AI review.
> 
> **Overview**
> Adds two thin GitHub Actions wrappers that delegate to reusable workflows in **j5ik2o/ci**, pinned at commit `560170b61c74a9a643a483a052ccbad0d6ad409a` (both `uses:` ref and `ci_ref` input).
> 
> **Review Thread Resolution** runs on review/comment events, a 15-minute cron, and manual dispatch; it forwards optional `pr_number` and `wait_for_other_checks` and grants permissions needed to refresh check/status state for review threads.
> 
> **TAKT Review** runs on PR lifecycle events and on trusted `@takt` issue comments when `vars.TAKT_REVIEW_ENABLED == 'true'`; it passes `ANTHROPIC_API_KEY`, uses the default TAKT review workflow with Claude Sonnet 4.5, and runs as **non-blocking**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8435e5a016d433dcc9b2957982731296f74a1e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->